### PR TITLE
Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        pip list
+    - name: Lint with Black
+      run: |
+        black --check --diff --verbose .
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx


### PR DESCRIPTION
Add CI with GitHub Actions that runs on Python 3.6 and Python 3.7 across Ubuntu, MacOS, and Windows. The CI install from source, lints with Black, and then runs pytest. A cron job will run every night at 0:01 UTC as well.