### PR TITLE
fix: clear FORCE_COLOR and randomize port for tests

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -59,6 +59,12 @@ pytest = ">=9"
 pytest-cov = ">=3"
 respx = ">=0.21"
 
+[feature.test.activation.env]
+# Rich's Console checks FORCE_COLOR at construction time (module import), before
+# any test-level env patching can take effect. Clearing it here ensures pytest
+# runs with a non-TTY console so output contains no ANSI escape codes.
+FORCE_COLOR = ""
+
 [feature.test.tasks]
 test = { cmd = "pytest -m 'not slow'", description = "Run quick tests (skip slow)" }
 test-cov = { cmd = "pytest -m 'not slow' --cov=stare --cov-report=term --cov-report=html", description = "Run quick tests with coverage" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,8 +37,8 @@ def pytest_collection_modifyitems(
 
 def _free_port() -> int:
     """Return an available TCP port on localhost."""
-    with socket.socket() as s:
-        s.bind(("", 0))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
         return int(s.getsockname()[1])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import socket
 import time
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,13 @@ def pytest_collection_modifyitems(
                 item.add_marker(skip_slow)
 
 
+def _free_port() -> int:
+    """Return an available TCP port on localhost."""
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return int(s.getsockname()[1])
+
+
 @pytest.fixture
 def test_settings() -> StareSettings:
     """StareSettings pointing at a test base URL."""
@@ -46,7 +54,7 @@ def test_settings() -> StareSettings:
         jwks_url="https://auth.example.com/realms/test/certs",
         client_id="test-client",
         scopes="openid",
-        callback_port=18182,
+        callback_port=_free_port(),
         exchange_audience=None,
         cache_enabled=False,
     )


### PR DESCRIPTION
## Summary

- `Rich`'s `Console` checks `FORCE_COLOR` at construction time (module import), before any test-level env patching can take effect
- When `FORCE_COLOR=3` is set in CI (via the workflow `env:` block), Rich treats the captured test output as a color terminal and emits ANSI escape codes — breaking plain-string assertions like `assert '0.2.0' in result.output`
- Clearing `FORCE_COLOR` in `[feature.test.activation.env]` ensures it's empty before pytest starts, so the module-level `Console()` in `cli/utils.py` sees a non-TTY and emits no ANSI codes

## Test plan

- [ ] CI passes on this PR (previously failing on `main` too — missed from the original big PR)
- [ ] Locally: `pixi run -e py313 test` passes; `pixi run -e py313 python -c "import os; print(repr(os.environ.get('FORCE_COLOR')))"` prints `''`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to avoid forcing console color handling during test initialization, reducing spurious color-related output.
* **Tests**
  * Test runtime now allocates callback ports dynamically per run to prevent port collisions and improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->