### PR TITLE
fix: Use hatch-vcs and fix up version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.26"]
+requires = ["hatchling>=1.26", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -70,7 +70,8 @@ docs = [
 
 
 [tool.hatch]
-version.path = "src/stare/__init__.py"
+version.source = "vcs"
+build.hooks.vcs.version-file = "src/stare/_version.py"
 
 [tool.hatch.envs.default]
 dependency-groups = ["dev"]

--- a/src/stare/__init__.py
+++ b/src/stare/__init__.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "0.2.0"
-
+from stare._version import version as __version__
 from stare.client import Glance
 
 __all__ = ["Glance", "__version__"]

--- a/src/stare/_version.pyi
+++ b/src/stare/_version.pyi
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+version: str
+version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]

--- a/src/stare/_version.pyi
+++ b/src/stare/_version.pyi
@@ -1,4 +1,2 @@
-from __future__ import annotations
-
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored versioning configuration to use VCS-based versioning. Version information is now automatically derived from Git metadata rather than being manually maintained. Updated build system and type definitions to support dynamic version generation during package builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->