### PR TITLE
feat: update to new API, set production exchange token default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,7 @@ library.
 | `STARE_SCOPES`                        | `openid`                                                               | Space-separated OAuth2 scopes                                         |
 | `STARE_CALLBACK_PORT`                 | `8182`                                                                 | Local port for the PKCE redirect callback; must match Keycloak config |
 | `STARE_VERBOSE`                       | `false`                                                                | Set to `1` to enable DEBUG-level request logging (httpx/httpcore)     |
-| `STARE_EXCHANGE_AUDIENCE`             | _(not set)_                                                            | RFC 8693 target audience; enables token exchange when set             |
+| `STARE_EXCHANGE_AUDIENCE`             | `atlas-glance-analysis-api-prod`                                       | RFC 8693 target audience for token exchange; set for production by default |
 | `STARE_EXCHANGE_TOKEN_BUFFER_SECONDS` | `120`                                                                  | Re-exchange the token this many seconds before expiry                 |
 | `STARE_TOKEN_EXPIRY_MARGIN_SECONDS`   | `60`                                                                   | Trigger refresh this many seconds before the access token expires     |
 | `STARE_CA_BUNDLE`                     | `Sectigo`                                                              | TLS CA bundle: `Sectigo` (production) or `CERN` (staging)             |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,26 +11,26 @@ reads environment variables with the `STARE_` prefix. Override any default by
 setting the corresponding variable before running `stare` or importing the
 library.
 
-| Variable                              | Default                                                                | Description                                                           |
-| ------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `STARE_BASE_URL`                      | `https://atlas-glance.cern.ch/atlas/analysis/api`                      | Glance/Fence API base URL                                             |
-| `STARE_AUTH_URL`                      | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/auth`   | Keycloak authorization endpoint                                       |
-| `STARE_TOKEN_URL`                     | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/token`  | Keycloak token endpoint                                               |
-| `STARE_REVOCATION_URL`                | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/revoke` | Keycloak token revocation endpoint                                    |
-| `STARE_ISSUER`                        | `https://auth.cern.ch/auth/realms/cern`                                | Expected JWT issuer (validated on login)                              |
-| `STARE_JWKS_URL`                      | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/certs`  | JWKS endpoint for ID token signature verification                     |
-| `STARE_CLIENT_ID`                     | `stare`                                                                | OAuth2 client identifier                                              |
-| `STARE_SCOPES`                        | `openid`                                                               | Space-separated OAuth2 scopes                                         |
-| `STARE_CALLBACK_PORT`                 | `8182`                                                                 | Local port for the PKCE redirect callback; must match Keycloak config |
-| `STARE_VERBOSE`                       | `false`                                                                | Set to `1` to enable DEBUG-level request logging (httpx/httpcore)     |
+| Variable                              | Default                                                                | Description                                                                |
+| ------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `STARE_BASE_URL`                      | `https://atlas-glance.cern.ch/atlas/analysis/api`                      | Glance/Fence API base URL                                                  |
+| `STARE_AUTH_URL`                      | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/auth`   | Keycloak authorization endpoint                                            |
+| `STARE_TOKEN_URL`                     | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/token`  | Keycloak token endpoint                                                    |
+| `STARE_REVOCATION_URL`                | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/revoke` | Keycloak token revocation endpoint                                         |
+| `STARE_ISSUER`                        | `https://auth.cern.ch/auth/realms/cern`                                | Expected JWT issuer (validated on login)                                   |
+| `STARE_JWKS_URL`                      | `https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/certs`  | JWKS endpoint for ID token signature verification                          |
+| `STARE_CLIENT_ID`                     | `stare`                                                                | OAuth2 client identifier                                                   |
+| `STARE_SCOPES`                        | `openid`                                                               | Space-separated OAuth2 scopes                                              |
+| `STARE_CALLBACK_PORT`                 | `8182`                                                                 | Local port for the PKCE redirect callback; must match Keycloak config      |
+| `STARE_VERBOSE`                       | `false`                                                                | Set to `1` to enable DEBUG-level request logging (httpx/httpcore)          |
 | `STARE_EXCHANGE_AUDIENCE`             | `atlas-glance-analysis-api-prod`                                       | RFC 8693 target audience for token exchange; set for production by default |
-| `STARE_EXCHANGE_TOKEN_BUFFER_SECONDS` | `120`                                                                  | Re-exchange the token this many seconds before expiry                 |
-| `STARE_TOKEN_EXPIRY_MARGIN_SECONDS`   | `60`                                                                   | Trigger refresh this many seconds before the access token expires     |
-| `STARE_CA_BUNDLE`                     | `Sectigo`                                                              | TLS CA bundle: `Sectigo` (production) or `CERN` (staging)             |
-| `STARE_WEB_BASE_URL`                  | `https://atlas-glance.cern.ch/atlas/analysis`                          | Web UI base URL for clickable hyperlinks in CLI output                |
-| `STARE_CACHE_ENABLED`                 | `true`                                                                 | Enable on-disk HTTP response cache                                    |
-| `STARE_CACHE_TTL_SECONDS`             | `28800`                                                                | Cache TTL in seconds (default: 8 hours)                               |
-| `STARE_CACHE_DIR`                     | _(platform user cache dir)_                                            | Override the cache directory path                                     |
+| `STARE_EXCHANGE_TOKEN_BUFFER_SECONDS` | `120`                                                                  | Re-exchange the token this many seconds before expiry                      |
+| `STARE_TOKEN_EXPIRY_MARGIN_SECONDS`   | `60`                                                                   | Trigger refresh this many seconds before the access token expires          |
+| `STARE_CA_BUNDLE`                     | `Sectigo`                                                              | TLS CA bundle: `Sectigo` (production) or `CERN` (staging)                  |
+| `STARE_WEB_BASE_URL`                  | `https://atlas-glance.cern.ch/atlas/analysis`                          | Web UI base URL for clickable hyperlinks in CLI output                     |
+| `STARE_CACHE_ENABLED`                 | `true`                                                                 | Enable on-disk HTTP response cache                                         |
+| `STARE_CACHE_TTL_SECONDS`             | `28800`                                                                | Cache TTL in seconds (default: 8 hours)                                    |
+| `STARE_CACHE_DIR`                     | _(platform user cache dir)_                                            | Override the cache directory path                                          |
 
 ## Using a custom settings object
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,366 @@
+---
+icon: lucide/book-open
+---
+
+# Examples
+
+All library examples use the [`Glance`][stare.Glance] client. Authentication is
+handled automatically from your stored token (run `stare auth login` once). See
+[Authentication](auth.md) for CI environments that need token injection.
+
+---
+
+## Search analyses
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    result = g.analyses.search()  # (1)!
+    print(f"{result.number_of_results} analyses total")
+    for analysis in result.results:
+        print(analysis.reference_code, analysis.short_title)
+    ```
+
+    1. No query means "return everything" — the server default is 50 results per
+       page. Use `limit` and `offset` to paginate; see the
+       [pagination example](#paginate-through-all-results) below.
+
+=== "CLI"
+
+    ```bash
+    stare analysis search
+    stare analysis search --json  # (1)!
+    ```
+
+    1. `--json` forces machine-readable JSON output in a terminal. JSON is
+       emitted automatically when stdout is a pipe or file.
+
+---
+
+## Filter with the DSL
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    result = g.analyses.search(
+        query="groups.leadingGroup = HIGG",  # (1)!
+        limit=10,
+        sort_by="creationDate",  # (2)!
+        sort_desc=True,
+    )
+    for analysis in result.results:
+        print(analysis.reference_code, analysis.status)
+    ```
+
+    1. The query language supports `=`, `!=`, `contain`, and `not-contain`. Fields
+       use camelCase API names. See [Query DSL](query-dsl.md) for the full grammar
+       and field catalogue.
+    2. `sort_by` accepts any camelCase API field name. Pair with `sort_desc=True`
+       to reverse the order.
+
+=== "CLI"
+
+    ```bash
+    # Filter by leading group
+    stare analysis search -q 'groups.leadingGroup = HIGG' -n 10
+
+    # Sort by creation date, most recent first
+    stare analysis search -q 'groups.leadingGroup = HIGG' \
+      --sort-by creationDate --sort-desc --limit 10
+
+    # Pipe to jq for field extraction
+    stare analysis search -q 'groups.leadingGroup = HIGG' \
+      | jq -r '.results[] | select(.status == "Active") | .referenceCode'
+    ```
+
+---
+
+## Look up a specific analysis
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    result = g.analyses.search(
+        query="referenceCode = ANA-HION-2018-01",
+        limit=1,
+    )
+    analysis = result.results[0]
+    print(analysis.reference_code, analysis.status)
+    if analysis.groups:
+        print("leading group:", analysis.groups.leading_group)
+    ```
+
+=== "CLI"
+
+    ```bash
+    stare analysis search -q 'referenceCode = ANA-HION-2018-01'
+
+    # JSON output — pipe to jq for field extraction
+    stare analysis search -q 'referenceCode = ANA-HION-2018-01' --json \
+      | jq '.results[0] | {referenceCode, status}'
+    ```
+
+---
+
+## Inspect the analysis team
+
+```python
+from stare import Glance
+
+g = Glance()
+result = g.analyses.search(
+    query="referenceCode = ANA-HION-2018-01", limit=1
+)
+analysis = result.results[0]
+
+editors = [m for m in analysis.analysis_team if m.is_contact_editor]  # (1)!
+print(f"{len(editors)} contact editor(s):")
+for editor in editors:
+    print(f"  {editor.first_name} {editor.last_name} ({editor.cern_ccid})")
+```
+
+1. `is_contact_editor` is a `bool`. Contact editors are the primary points of
+   contact for the analysis.
+
+---
+
+## Inspect phase 0 meetings
+
+```python
+from stare import Glance
+from stare.models.enums import MeetingType
+
+g = Glance()
+result = g.analyses.search(
+    query="referenceCode = ANA-HION-2018-01", limit=1
+)
+analysis = result.results[0]
+
+if analysis.phase0:
+    for meeting in analysis.phase0.meetings:  # (1)!
+        label = MeetingType(meeting.meeting_type).name.replace("_", " ").title()
+        print(f"[{label}] {meeting.title} — {meeting.date}")
+        if meeting.link and meeting.link.url:
+            print(f"  {meeting.link.url}")
+```
+
+1. Meetings from all four phase 0 buckets (`eoiMeeting`,
+   `editorialBoardRequestMeeting`, `preApprovalMeeting`, `approvalMeeting`) are
+   flattened into a single `meetings` list, each tagged with its
+   [`MeetingType`][stare.models.enums.MeetingType].
+
+---
+
+## Search papers
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    result = g.papers.search(
+        query="groups.leadingGroup = HDBS",
+        limit=10,
+    )
+    print(f"{result.number_of_results} papers total, showing {len(result.results)}")
+    for paper in result.results:
+        print(paper.reference_code, paper.status)
+    ```
+
+=== "CLI"
+
+    ```bash
+    stare paper search -q 'groups.leadingGroup = HDBS' -n 10
+
+    # Emit (reference_code, status) pairs as TSV
+    stare paper search -q 'groups.leadingGroup = HDBS' \
+      | jq -r '.results[] | [.referenceCode, .status] | @tsv'
+    ```
+
+---
+
+## Access paper submission data
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    result = g.papers.search(
+        query="referenceCode = EXOT-2018-14", limit=1
+    )
+    paper = result.results[0]
+
+    if paper.submission:  # (1)!
+        for link in paper.submission.arxiv_urls:  # (2)!
+            print(f"arXiv: {link.label}  →  {link.url}")
+        for pub in paper.submission.final_journal_publications:  # (3)!
+            print(f"Journal: {pub.label}  →  {pub.url}")
+        for brief in paper.submission.physics_briefings:
+            print(f"Briefing: {brief.label}  →  {brief.url}")
+    ```
+
+    1. `submission` is `None` when the paper has not yet reached the submission
+       phase.
+    2. A paper may have multiple arXiv entries (e.g. when the arXiv identifier
+       changes during the submission process).
+    3. Final journal publications and physics briefings are also lists — a paper can
+       appear in more than one journal or have several briefings.
+
+=== "CLI"
+
+    ```bash
+    stare paper search -q 'referenceCode = EXOT-2018-14' --json \
+      | jq '.results[0].submission.arXivUrls'
+
+    stare paper search -q 'referenceCode = EXOT-2018-14' --json \
+      | jq -r '.results[0].submission.finalJournalPublication[] | "\(.label)  →  \(.url)"'
+    ```
+
+---
+
+## Paginate through all results
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+
+    g = Glance()
+    limit = 50
+    offset = 0
+    all_codes: list[str] = []
+
+    while True:
+        result = g.analyses.search(
+            query="groups.leadingGroup = HIGG",
+            limit=limit,
+            offset=offset,
+        )
+        all_codes.extend(
+            a.reference_code for a in result.results if a.reference_code
+        )
+        offset += len(result.results)
+        if offset >= (result.number_of_results or 0):  # (1)!
+            break
+
+    print(f"Collected {len(all_codes)} HIGG analyses")
+    ```
+
+    1. `number_of_results` is the server-side total count, not the number of items
+       in the current page. Compare your running offset against it to know when
+       you've exhausted all pages.
+
+=== "CLI"
+
+    ```bash
+    # First page of 25
+    stare analysis search -q 'groups.leadingGroup = HIGG' --limit 25
+
+    # Second page of 25
+    stare analysis search -q 'groups.leadingGroup = HIGG' --limit 25 --offset 25
+
+    # Save a full result set to disk (auto-JSON when redirected)
+    stare analysis search -q 'groups.leadingGroup = HIGG' > higg_analyses.json
+    jq '.results | length' higg_analyses.json
+    ```
+
+---
+
+## Disable the cache
+
+=== "Python"
+
+    ```python
+    from stare import Glance
+    from stare.settings import StareSettings
+
+    g = Glance(settings=StareSettings(cache_enabled=False))  # (1)!
+    result = g.analyses.search(limit=5)
+    ```
+
+    1. Disabling the cache forces a fresh HTTP request every time. This is useful in
+       scripts that need up-to-the-minute data, or in tests that must not replay
+       stale responses. See [Caching](caching.md) for TTL configuration and
+       per-invocation bypass via `--no-cache`.
+
+=== "CLI"
+
+    ```bash
+    # Skip cache for a single invocation
+    stare analysis search --no-cache
+
+    # All HDBS papers, fresh data
+    stare paper search -q 'groups.leadingGroup = HDBS' --no-cache
+    ```
+
+---
+
+## Use as a context manager
+
+```python
+from stare import Glance
+
+with Glance() as g:  # (1)!
+    analyses = g.analyses.search(limit=5)
+    papers = g.papers.search(limit=5)
+
+print(analyses.results[0].reference_code)
+```
+
+1. The context manager closes the underlying HTTP connection pool when the block
+   exits. Outside a `with` block the connection pool is managed automatically,
+   but the context manager form is preferred in long-running scripts.
+
+---
+
+## Handle errors
+
+```python
+from stare import Glance
+from stare.exceptions import AuthenticationError, StareError
+
+try:
+    g = Glance()
+    result = g.analyses.search(query="referenceCode = ANA-HION-2018-01")
+except AuthenticationError:  # (1)!
+    print("Not authenticated — run `stare auth login` first")
+except StareError as exc:  # (2)!
+    print(f"API error: {exc}")
+```
+
+1. [`AuthenticationError`][stare.exceptions.AuthenticationError] is raised when
+   no valid token is stored or the stored token cannot be refreshed. Running
+   `stare auth login` resolves this.
+2. All `stare` exceptions inherit from
+   [`StareError`][stare.exceptions.StareError] — catching it handles network
+   failures, parse errors, and HTTP error responses in one place.
+
+---
+
+## Token injection (CI / scripting)
+
+In environments where interactive browser login is not possible, pass a token
+directly:
+
+```python
+import os
+from stare import Glance
+
+g = Glance(token=os.environ["GLANCE_TOKEN"])  # (1)!
+result = g.analyses.search(limit=5)
+```
+
+1. The `token` keyword skips the OS credential store entirely. Obtain the token
+   from `stare auth info --access-token` and store it as a CI secret.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -117,9 +117,7 @@ handled automatically from your stored token (run `stare auth login` once). See
 from stare import Glance
 
 g = Glance()
-result = g.analyses.search(
-    query="referenceCode = ANA-HION-2018-01", limit=1
-)
+result = g.analyses.search(query="referenceCode = ANA-HION-2018-01", limit=1)
 analysis = result.results[0]
 
 editors = [m for m in analysis.analysis_team if m.is_contact_editor]  # (1)!
@@ -140,9 +138,7 @@ from stare import Glance
 from stare.models.enums import MeetingType
 
 g = Glance()
-result = g.analyses.search(
-    query="referenceCode = ANA-HION-2018-01", limit=1
-)
+result = g.analyses.search(query="referenceCode = ANA-HION-2018-01", limit=1)
 analysis = result.results[0]
 
 if analysis.phase0:
@@ -197,9 +193,7 @@ if analysis.phase0:
     from stare import Glance
 
     g = Glance()
-    result = g.papers.search(
-        query="referenceCode = EXOT-2018-14", limit=1
-    )
+    result = g.papers.search(query="referenceCode = EXOT-2018-14", limit=1)
     paper = result.results[0]
 
     if paper.submission:  # (1)!
@@ -248,9 +242,7 @@ if analysis.phase0:
             limit=limit,
             offset=offset,
         )
-        all_codes.extend(
-            a.reference_code for a in result.results if a.reference_code
-        )
+        all_codes.extend(a.reference_code for a in result.results if a.reference_code)
         offset += len(result.results)
         if offset >= (result.number_of_results or 0):  # (1)!
             break

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,7 @@ g = Glance()
 
 # Search analyses (live)
 result = g.analyses.search(query="referenceCode = ANA-HION-2018-01")
-print(f"Found {result.total_rows} analyses")
+print(f"Found {result.number_of_results} analyses")
 for analysis in result.results:
     print(analysis.reference_code, analysis.short_title)
 

--- a/src/stare/cli/analysis.py
+++ b/src/stare/cli/analysis.py
@@ -104,7 +104,7 @@ def analysis_search(
         return
 
     settings = StareSettings()
-    table = Table(title=f"Analyses ({result.total_rows} total)")
+    table = Table(title=f"Analyses ({result.number_of_results} total)")
     table.add_column("Reference Code", style="cyan")
     table.add_column("Status")
     table.add_column("Short Title")

--- a/src/stare/cli/paper.py
+++ b/src/stare/cli/paper.py
@@ -103,7 +103,7 @@ def paper_search(
         return
 
     settings = StareSettings()
-    table = Table(title=f"Papers ({result.total_rows} total)")
+    table = Table(title=f"Papers ({result.number_of_results} total)")
     table.add_column("Reference Code", style="cyan")
     table.add_column("Status")
     table.add_column("Short Title")

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -139,7 +139,7 @@ class Person(_Base):
 class TeamMember(Person):
     """A member of an analysis team."""
 
-    is_contact_editor: str | None = None
+    is_contact_editor: bool | None = None
 
 
 class EditorialBoardMember(Person):
@@ -222,11 +222,14 @@ class Meeting(_Base):
     @model_validator(mode="before")
     @classmethod
     def _fold_link_fields(cls, data: Any) -> Any:
-        if isinstance(data, dict) and isinstance(data.get("link"), str):
-            link_url = data.pop("link", None)
-            link_label = data.pop("linkLabel", None)
-            if link_url is not None or link_label is not None:
-                data["link"] = {"label": link_label, "url": link_url}
+        if not isinstance(data, dict):
+            return data
+        # API sends flat label/url fields; fold them into a nested Link object.
+        if "link" not in data and ("label" in data or "url" in data):
+            label = data.pop("label", None)
+            url = data.pop("url", None)
+            if label is not None or url is not None:
+                data["link"] = {"label": label, "url": url}
         return data
 
 

--- a/src/stare/models/paper.py
+++ b/src/stare/models/paper.py
@@ -35,7 +35,7 @@ class PaperPhase1(_Base):
     eb_draft_sign_off: str | None = Field(
         default=None, alias="editorialBoardDraftSignOff"
     )
-    released_on: date | None = None
+    draft_released_on: date | None = Field(default=None, alias="draftReleasedDate")
     pub_committee_chair: Person | None = Field(
         default=None, alias="publicationCommitteeChairDeputyOrDelegatedTo"
     )
@@ -56,11 +56,13 @@ class PaperPhase2(_Base):
     eb_draft2_sign_off_on: date | None = Field(
         default=None, alias="editorialBoardDraft2SignOffOn"
     )
-    released_on: date | None = None
+    draft2_released_on: date | None = Field(default=None, alias="draft2ReleasedDate")
     sent_draft2_to_cern_on: date | None = None
-    signed_off_by_cern_on: date | None = None
+    draft2_cern_sign_off_on: date | None = Field(
+        default=None, alias="draft2CernSignOffDate"
+    )
     paper_closure_meeting_urls: list[Link] = Field(default_factory=list)
-    preliminary_plots_released: str | None = Field(
+    preliminary_plots_released: bool | None = Field(
         default=None, alias="preliminaryPlotsAndResultsReleased"
     )
     date_of_paper_closure: date | None = None
@@ -82,17 +84,19 @@ class SubmissionPhase(_Base):
 
     state: LenientPhaseState | None = None
     start_date: date | None = None
-    arxiv_url: Link | None = Field(default=None, alias="arXivUrl")
+    arxiv_urls: list[Link] = Field(default_factory=list, alias="arXivUrls")
     final_title: str | None = Field(default=None, alias="finalTitleTex")
     final_submission_journal: str | None = None
     arxiv_submission_date: AwareDatetime | None = Field(
         default=None, alias="arXivSubmissionDate"
     )
-    physics_briefing: Link | None = None
+    physics_briefings: list[Link] = Field(default_factory=list, alias="physicsBriefing")
     date_of_1st_referee_report: date | None = None
     journal_acceptance_date: date | None = None
     date_of_1st_proof: date | None = None
-    final_journal_publication: Link | None = None
+    final_journal_publications: list[Link] = Field(
+        default_factory=list, alias="finalJournalPublication"
+    )
     published_online_on: date | None = None
 
     @field_validator("arxiv_submission_date", mode="before")
@@ -122,4 +126,4 @@ class Paper(_Base):
     associated_analysis: RelatedPublication | None = None
     phase1: PaperPhase1 | None = None
     phase2: PaperPhase2 | None = None
-    submission_phase: SubmissionPhase | None = None
+    submission: SubmissionPhase | None = None

--- a/src/stare/models/search.py
+++ b/src/stare/models/search.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar
 
-from pydantic import AliasChoices, Field
+from pydantic import Field
 
 from stare.models.analysis import Analysis
 from stare.models.common import _Base
@@ -15,19 +15,9 @@ T = TypeVar("T")
 
 
 class _SearchResultsBase(_Base, Generic[T]):
-    """Generic search result container shared by all search endpoints.
+    """Generic search result container shared by all search endpoints."""
 
-    The two live endpoints return different JSON keys for the total count
-    (``totalRows`` from /searchAnalysis, ``numberOfResults`` from
-    /searchPaper).  Both are accepted and stored under the same Python
-    attribute ``total_rows``.
-    """
-
-    total_rows: int | None = Field(
-        default=None,
-        validation_alias=AliasChoices("totalRows", "numberOfResults"),
-        serialization_alias="numberOfResults",
-    )
+    number_of_results: int | None = Field(default=None, alias="numberOfResults")
     results: list[T] = Field(default_factory=list)
 
 

--- a/src/stare/settings.py
+++ b/src/stare/settings.py
@@ -26,9 +26,9 @@ class StareSettings(BaseSettings):
     # Set STARE_VERBOSE=1 to enable DEBUG-level httpx/httpcore request logging.
     verbose: bool = False
     # RFC 8693 token exchange: exchange the PKCE access token for a token
-    # scoped to this audience before each API call. Disabled by default; set
-    # STARE_EXCHANGE_AUDIENCE=atlas-analysis-api (or similar) to enable.
-    exchange_audience: str | None = None
+    # scoped to this audience before each API call. Defaults to the production
+    # audience; set STARE_EXCHANGE_AUDIENCE='' to disable exchange entirely.
+    exchange_audience: str | None = "atlas-glance-analysis-api-prod"
     revocation_url: str = (
         "https://auth.cern.ch/auth/realms/cern/protocol/openid-connect/revoke"
     )

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -152,9 +152,7 @@ def test_paginate_through_results(glance: Glance) -> None:
             limit=limit,
             offset=offset,
         )
-        all_codes.extend(
-            a.reference_code for a in result.results if a.reference_code
-        )
+        all_codes.extend(a.reference_code for a in result.results if a.reference_code)
         offset += len(result.results)
         if offset >= (result.number_of_results or 0):
             break

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -187,6 +187,6 @@ def test_context_manager() -> None:
 
 
 @pytest.mark.slow
-def test_error_handling_auth_error_type(glance: Glance) -> None:
+def test_error_handling_auth_error_type() -> None:
     """docs/examples.md — AuthenticationError is a subclass of StareError."""
     assert issubclass(AuthenticationError, StareError)

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -1,0 +1,194 @@
+"""Integration tests that exercise the code examples shown in docs/examples.md.
+
+Each test is a close translation of one documented example. They run against
+the live ATLAS Glance API and are skipped by default.
+
+Run with::
+
+    pixi run test-slow
+
+or::
+
+    pytest --runslow tests/integration/test_examples.py
+
+Requires a valid CERN SSO session (``stare auth login``).
+``STARE_EXCHANGE_AUDIENCE`` defaults to the production audience and does not
+need to be set explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from stare import Glance
+from stare.exceptions import AuthenticationError, StareError
+from stare.models import Analysis, Paper
+from stare.models.enums import MeetingType
+from stare.settings import StareSettings
+
+_LIVE = StareSettings(cache_enabled=False)
+_REF_ANALYSIS = "ANA-HION-2018-01"
+_REF_PAPER = "EXOT-2018-14"
+
+
+@pytest.fixture(scope="session")
+def glance() -> Glance:
+    """Session-scoped Glance client."""
+    return Glance(settings=_LIVE)
+
+
+# ---------------------------------------------------------------------------
+# Analysis examples
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_search_analyses(glance: Glance) -> None:
+    """docs/examples.md — Search analyses."""
+    result = glance.analyses.search()
+    assert result.number_of_results is not None
+    assert result.number_of_results > 0
+    for analysis in result.results:
+        assert isinstance(analysis, Analysis)
+
+
+@pytest.mark.slow
+def test_filter_with_dsl(glance: Glance) -> None:
+    """docs/examples.md — Filter with the DSL."""
+    result = glance.analyses.search(
+        query="groups.leadingGroup = HIGG",
+        limit=10,
+        sort_by="creationDate",
+        sort_desc=True,
+    )
+    assert result.number_of_results is not None
+    assert result.number_of_results > 0
+    for analysis in result.results:
+        assert analysis.groups is not None
+        assert analysis.groups.leading_group == "HIGG"
+
+
+@pytest.mark.slow
+def test_look_up_specific_analysis(glance: Glance) -> None:
+    """docs/examples.md — Look up a specific analysis."""
+    result = glance.analyses.search(query=f"referenceCode = {_REF_ANALYSIS}", limit=1)
+    assert len(result.results) == 1
+    analysis = result.results[0]
+    assert analysis.reference_code == _REF_ANALYSIS
+    assert analysis.groups is not None
+    assert analysis.groups.leading_group is not None
+
+
+@pytest.mark.slow
+def test_inspect_analysis_team(glance: Glance) -> None:
+    """docs/examples.md — Inspect the analysis team."""
+    result = glance.analyses.search(query=f"referenceCode = {_REF_ANALYSIS}", limit=1)
+    analysis = result.results[0]
+    editors = [m for m in analysis.analysis_team if m.is_contact_editor]
+    assert len(editors) >= 1
+    for editor in editors:
+        assert isinstance(editor.is_contact_editor, bool)
+        assert editor.cern_ccid is not None
+
+
+@pytest.mark.slow
+def test_inspect_phase0_meetings(glance: Glance) -> None:
+    """docs/examples.md — Inspect phase 0 meetings."""
+    result = glance.analyses.search(query=f"referenceCode = {_REF_ANALYSIS}", limit=1)
+    analysis = result.results[0]
+    assert analysis.phase0 is not None
+    assert len(analysis.phase0.meetings) > 0
+    for meeting in analysis.phase0.meetings:
+        assert MeetingType(meeting.meeting_type) in list(MeetingType)
+        if meeting.link is not None:
+            assert meeting.link.url is not None
+
+
+# ---------------------------------------------------------------------------
+# Paper examples
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_search_papers(glance: Glance) -> None:
+    """docs/examples.md — Search papers."""
+    result = glance.papers.search(query="groups.leadingGroup = HDBS", limit=10)
+    assert result.number_of_results is not None
+    assert result.number_of_results > 0
+    for paper in result.results:
+        assert isinstance(paper, Paper)
+
+
+@pytest.mark.slow
+def test_paper_submission_data(glance: Glance) -> None:
+    """docs/examples.md — Access paper submission data."""
+    result = glance.papers.search(query=f"referenceCode = {_REF_PAPER}", limit=1)
+    assert len(result.results) == 1
+    paper = result.results[0]
+    assert paper.submission is not None
+    assert len(paper.submission.arxiv_urls) >= 1
+    for link in paper.submission.arxiv_urls:
+        assert link.url is not None
+    assert isinstance(paper.submission.physics_briefings, list)
+    assert isinstance(paper.submission.final_journal_publications, list)
+    assert len(paper.submission.final_journal_publications) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Pagination example
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_paginate_through_results(glance: Glance) -> None:
+    """docs/examples.md — Paginate through all results."""
+    limit = 10
+    offset = 0
+    all_codes: list[str] = []
+
+    while True:
+        result = glance.analyses.search(
+            query="groups.leadingGroup = HIGG",
+            limit=limit,
+            offset=offset,
+        )
+        all_codes.extend(
+            a.reference_code for a in result.results if a.reference_code
+        )
+        offset += len(result.results)
+        if offset >= (result.number_of_results or 0):
+            break
+        if offset >= 30:  # cap at 3 pages to keep the test fast
+            break
+
+    assert len(all_codes) > 0
+
+
+# ---------------------------------------------------------------------------
+# Cache / context manager / error handling examples
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_disable_cache() -> None:
+    """docs/examples.md — Disable the cache (uses its own Glance instance)."""
+    g = Glance(settings=StareSettings(cache_enabled=False))
+    result = g.analyses.search(limit=5)
+    assert result.number_of_results is not None
+    assert result.number_of_results > 0
+
+
+@pytest.mark.slow
+def test_context_manager() -> None:
+    """docs/examples.md — Use as a context manager."""
+    with Glance(settings=_LIVE) as g:
+        analyses = g.analyses.search(limit=5)
+        papers = g.papers.search(limit=5)
+    assert len(analyses.results) > 0
+    assert len(papers.results) > 0
+
+
+@pytest.mark.slow
+def test_error_handling_auth_error_type(glance: Glance) -> None:
+    """docs/examples.md — AuthenticationError is a subclass of StareError."""
+    assert issubclass(AuthenticationError, StareError)

--- a/tests/integration/test_live.py
+++ b/tests/integration/test_live.py
@@ -57,8 +57,8 @@ def reference_analysis() -> Analysis:
             )
     except StareError as exc:
         pytest.skip(f"Live API unavailable: {exc}")
-    assert result.total_rows is not None
-    assert result.total_rows >= 1
+    assert result.number_of_results is not None
+    assert result.number_of_results >= 1
     match = next(
         (a for a in result.results if a.reference_code == _REFERENCE_ANALYSIS_CODE),
         None,
@@ -73,8 +73,8 @@ def test_search_analyses_returns_results() -> None:
     with Glance(settings=_LIVE_SETTINGS) as g:
         result = g.analyses.search(limit=5)
     assert isinstance(result, AnalysisSearchResult)
-    assert result.total_rows is not None
-    assert result.total_rows > 0
+    assert result.number_of_results is not None
+    assert result.number_of_results > 0
     assert len(result.results) > 0
 
 
@@ -85,8 +85,8 @@ def test_search_analyses_by_reference_code() -> None:
         result = g.analyses.search(
             query=f"referenceCode = {_REFERENCE_ANALYSIS_CODE}", limit=1
         )
-    assert result.total_rows is not None
-    assert result.total_rows >= 1
+    assert result.number_of_results is not None
+    assert result.number_of_results >= 1
     assert any(a.reference_code == _REFERENCE_ANALYSIS_CODE for a in result.results)
 
 
@@ -119,5 +119,5 @@ def test_analysis_field_is_searchable(field: str, reference_analysis: Analysis) 
             limit=1,
             validate_query=False,
         )
-    assert result.total_rows is not None
-    assert result.total_rows >= 1
+    assert result.number_of_results is not None
+    assert result.number_of_results >= 1

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -167,7 +167,7 @@ class TestNoCacheFlag:
     def test_no_cache_flag_is_accepted(self) -> None:
         g = MagicMock()
         g.analyses.search.return_value = AnalysisSearchResult.model_validate(
-            {"totalRows": 0, "results": []}
+            {"numberOfResults": 0, "results": []}
         )
         with patch("stare.cli.utils.make_glance", return_value=g):
             result = runner.invoke(app, ["analysis", "search", "--no-cache"])
@@ -176,7 +176,7 @@ class TestNoCacheFlag:
     def test_no_cache_calls_make_glance_with_flag(self) -> None:
         g = MagicMock()
         g.analyses.search.return_value = AnalysisSearchResult.model_validate(
-            {"totalRows": 0, "results": []}
+            {"numberOfResults": 0, "results": []}
         )
         with patch("stare.cli.utils.make_glance", return_value=g) as mock_make:
             runner.invoke(app, ["analysis", "search", "--no-cache"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,7 @@ SAMPLE_PUB_NOTE = PubNote.model_validate(
 
 SAMPLE_SEARCH = AnalysisSearchResult.model_validate(
     {
-        "totalRows": 1,
+        "numberOfResults": 1,
         "results": [
             {
                 "referenceCode": "ANA-TEST-2024-01",
@@ -636,7 +636,7 @@ def test_auto_detect_non_tty_emits_json() -> None:
         result = runner.invoke(app, ["analysis", "search"])
     assert result.exit_code == 0
     data = json.loads(result.output)
-    assert "numberOfResults" in data or "totalRows" in data
+    assert "numberOfResults" in data
 
 
 def test_no_json_forces_rich_table() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -54,7 +54,7 @@ SAMPLE_ANALYSIS = {
 }
 
 SAMPLE_SEARCH = {
-    "totalRows": 1,
+    "numberOfResults": 1,
     "results": [SAMPLE_ANALYSIS],
 }
 
@@ -148,7 +148,7 @@ def test_analyses_search_returns_search_result(glance: Glance) -> None:
         result = glance.analyses.search()
 
     assert isinstance(result, AnalysisSearchResult)
-    assert result.total_rows == 1
+    assert result.number_of_results == 1
     assert len(result.results) == 1
     assert isinstance(result.results[0], Analysis)
     assert result.results[0].reference_code == "ANA-TEST-2024-01"
@@ -157,7 +157,7 @@ def test_analyses_search_returns_search_result(glance: Glance) -> None:
 def test_analyses_search_passes_query_params(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search(query="referenceCode = X", limit=10, offset=5)
         params = dict(rx.calls[0].request.url.params)
@@ -169,7 +169,7 @@ def test_analyses_search_passes_query_params(glance: Glance) -> None:
 def test_analyses_search_sort_params(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search(sort_by="referenceCode", sort_desc=True)
         params = dict(rx.calls[0].request.url.params)
@@ -180,7 +180,7 @@ def test_analyses_search_sort_params(glance: Glance) -> None:
 def test_analyses_search_omits_none_params(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search()  # no query, no sort
         params = dict(rx.calls[0].request.url.params)
@@ -192,7 +192,7 @@ def test_analyses_search_omits_none_params(glance: Glance) -> None:
 def test_analyses_search_accepts_expression(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search(
             query=Condition(field="referenceCode", operator=Operator.EQ, value="X")
@@ -204,7 +204,7 @@ def test_analyses_search_accepts_expression(glance: Glance) -> None:
 def test_analyses_search_normalizes_snake_case_query(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search(query="reference_code = X")
         params = dict(rx.calls[0].request.url.params)
@@ -219,7 +219,7 @@ def test_analyses_search_rejects_unknown_field(glance: Glance) -> None:
 def test_analyses_search_validate_false_passes_raw(glance: Glance) -> None:
     with respx.mock(base_url=_BASE) as rx:
         rx.get("/searchAnalysis").mock(
-            return_value=httpx.Response(200, json={"totalRows": 0, "results": []})
+            return_value=httpx.Response(200, json={"numberOfResults": 0, "results": []})
         )
         glance.analyses.search(query="foo = bar", validate_query=False)
         params = dict(rx.calls[0].request.url.params)
@@ -301,7 +301,7 @@ def test_papers_search_returns_paper_search_result(glance: Glance) -> None:
         result = glance.papers.search()
 
     assert isinstance(result, PaperSearchResult)
-    assert result.total_rows == 1
+    assert result.number_of_results == 1
     assert len(result.results) == 1
     assert isinstance(result.results[0], Paper)
     assert result.results[0].reference_code == "HDBS-2024-01"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -71,11 +71,11 @@ class TestTeamMember:
                 "firstName": "X",
                 "lastName": "Y",
                 "email": "x@y.com",
-                "isContactEditor": "true",
+                "isContactEditor": True,
             }
         )
         assert m.cern_ccid == "x"
-        assert m.is_contact_editor == "true"
+        assert m.is_contact_editor is True
 
     def test_is_contact_editor_optional(self) -> None:
         m = TeamMember.model_validate({})
@@ -213,8 +213,8 @@ class TestMeeting:
                 "title": "EOI",
                 "date": "2023-01-15",
                 "comments": "ok",
-                "linkLabel": "Indico",
-                "link": "https://indico.cern.ch/e/1",
+                "label": "Indico",
+                "url": "https://indico.cern.ch/e/1",
             }
         )
         assert m.title == "EOI"
@@ -282,8 +282,8 @@ class TestAnalysisPhase0:
                         "title": "EOI",
                         "date": "2022-03-01",
                         "comments": "",
-                        "linkLabel": "Indico",
-                        "link": "https://indico.cern.ch",
+                        "label": "Indico",
+                        "url": "https://indico.cern.ch",
                     }
                 ],
                 "approvalMeeting": [],
@@ -381,7 +381,7 @@ class TestAnalysis:
                         "firstName": "A",
                         "lastName": "B",
                         "email": "a@b.com",
-                        "isContactEditor": "true",
+                        "isContactEditor": True,
                     }
                 ],
             }
@@ -429,32 +429,117 @@ class TestAnalysis:
 
 
 # ---------------------------------------------------------------------------
+# Paper models
+# ---------------------------------------------------------------------------
+
+
+from stare.models.paper import PaperPhase1, PaperPhase2, SubmissionPhase
+
+
+class TestPaperPhase1:
+    def test_draft_released_on(self) -> None:
+        p = PaperPhase1.model_validate({"draftReleasedDate": "2024-06-01"})
+        assert p.draft_released_on is not None
+        from datetime import date
+
+        assert p.draft_released_on == date(2024, 6, 1)
+
+    def test_all_optional(self) -> None:
+        p = PaperPhase1.model_validate({})
+        assert p.state is None
+        assert p.draft_released_on is None
+
+
+class TestPaperPhase2:
+    def test_draft2_fields(self) -> None:
+        p = PaperPhase2.model_validate(
+            {
+                "draft2ReleasedDate": "2024-07-01",
+                "draft2CernSignOffDate": "2024-08-01",
+                "preliminaryPlotsAndResultsReleased": True,
+            }
+        )
+        from datetime import date
+
+        assert p.draft2_released_on == date(2024, 7, 1)
+        assert p.draft2_cern_sign_off_on == date(2024, 8, 1)
+        assert p.preliminary_plots_released is True
+
+    def test_preliminary_plots_false(self) -> None:
+        p = PaperPhase2.model_validate({"preliminaryPlotsAndResultsReleased": False})
+        assert p.preliminary_plots_released is False
+
+    def test_all_optional(self) -> None:
+        p = PaperPhase2.model_validate({})
+        assert p.draft2_released_on is None
+        assert p.draft2_cern_sign_off_on is None
+        assert p.preliminary_plots_released is None
+
+
+class TestSubmissionPhase:
+    def test_arxiv_urls(self) -> None:
+        s = SubmissionPhase.model_validate(
+            {
+                "arXivUrls": [
+                    {"label": "arXiv:2501.00001", "url": "https://arxiv.org/abs/2501.00001"}
+                ]
+            }
+        )
+        assert len(s.arxiv_urls) == 1
+        assert s.arxiv_urls[0].label == "arXiv:2501.00001"
+
+    def test_physics_briefings(self) -> None:
+        s = SubmissionPhase.model_validate(
+            {
+                "physicsBriefing": [
+                    {"label": "Physics Briefing", "url": "https://atlas.cern/pb/1"}
+                ]
+            }
+        )
+        assert len(s.physics_briefings) == 1
+        assert s.physics_briefings[0].label == "Physics Briefing"
+
+    def test_final_journal_publications(self) -> None:
+        s = SubmissionPhase.model_validate(
+            {
+                "finalJournalPublication": [
+                    {"label": "JHEP 01 (2025) 001", "url": "https://doi.org/10.1007/x"}
+                ]
+            }
+        )
+        assert len(s.final_journal_publications) == 1
+        assert s.final_journal_publications[0].label == "JHEP 01 (2025) 001"
+
+    def test_all_optional(self) -> None:
+        s = SubmissionPhase.model_validate({})
+        assert s.arxiv_urls == []
+        assert s.physics_briefings == []
+        assert s.final_journal_publications == []
+
+
+# ---------------------------------------------------------------------------
 # Search / wrapper models
 # ---------------------------------------------------------------------------
 
 
 class TestAnalysisSearchResult:
-    def test_parse_totalrows_key(self) -> None:
+    def test_parse(self) -> None:
         r = AnalysisSearchResult.model_validate(
             {
-                "totalRows": 2,
+                "numberOfResults": 2,
                 "results": [
                     {"referenceCode": "ANA-A", "status": "Active"},
                     {"referenceCode": "ANA-B", "status": "Closed"},
                 ],
             }
         )
-        assert r.total_rows == 2
+        assert r.number_of_results == 2
         assert len(r.results) == 2
         assert r.results[0].reference_code == "ANA-A"
 
-    def test_parse_numberofresults_key(self) -> None:
-        r = AnalysisSearchResult.model_validate({"numberOfResults": 5, "results": []})
-        assert r.total_rows == 5
-
     def test_empty_results(self) -> None:
-        r = AnalysisSearchResult.model_validate({"totalRows": 0, "results": []})
-        assert r.total_rows == 0
+        r = AnalysisSearchResult.model_validate({"numberOfResults": 0, "results": []})
+        assert r.number_of_results == 0
         assert r.results == []
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -481,7 +481,10 @@ class TestSubmissionPhase:
         s = SubmissionPhase.model_validate(
             {
                 "arXivUrls": [
-                    {"label": "arXiv:2501.00001", "url": "https://arxiv.org/abs/2501.00001"}
+                    {
+                        "label": "arXiv:2501.00001",
+                        "url": "https://arxiv.org/abs/2501.00001",
+                    }
                 ]
             }
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,6 +24,7 @@ from stare.models.common import (
 )
 from stare.models.enums import MeetingType
 from stare.models.errors import ApiErrorResponse
+from stare.models.paper import PaperPhase1, PaperPhase2, SubmissionPhase
 from stare.models.search import AnalysisSearchResult, PublicationRef, Trigger
 
 # ---------------------------------------------------------------------------
@@ -433,15 +434,10 @@ class TestAnalysis:
 # ---------------------------------------------------------------------------
 
 
-from stare.models.paper import PaperPhase1, PaperPhase2, SubmissionPhase
-
-
 class TestPaperPhase1:
     def test_draft_released_on(self) -> None:
         p = PaperPhase1.model_validate({"draftReleasedDate": "2024-06-01"})
         assert p.draft_released_on is not None
-        from datetime import date
-
         assert p.draft_released_on == date(2024, 6, 1)
 
     def test_all_optional(self) -> None:
@@ -459,8 +455,6 @@ class TestPaperPhase2:
                 "preliminaryPlotsAndResultsReleased": True,
             }
         )
-        from datetime import date
-
         assert p.draft2_released_on == date(2024, 7, 1)
         assert p.draft2_cern_sign_off_on == date(2024, 8, 1)
         assert p.preliminary_plots_released is True

--- a/zensical.toml
+++ b/zensical.toml
@@ -11,6 +11,7 @@ Copyright &copy; 2019 Giordon Stark
 nav = [
   { "Home" = "index.md" },
   { "Getting started" = "getting-started.md" },
+  { "Examples" = "examples.md" },
   { "Query DSL" = "query-dsl.md" },
   { "Authentication" = "auth.md" },
   { "Configuration" = "configuration.md" },


### PR DESCRIPTION
- **feat: update models for new Glance API format**
- **docs: add Examples page with tabbed Python/CLI content and integration tests**
- **fix: default STARE_EXCHANGE_AUDIENCE to production audience**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive examples guide covering search, filtering, pagination, caching, error handling, and API usage patterns
  * Updated configuration documentation with production default for token exchange
  * Updated getting started guide with standardized API terminology

* **New Features**
  * Token exchange enabled by default using production audience

* **Bug Fixes**
  * Corrected contact editor field data type from string to boolean
  * Paper submission now properly supports multiple arXiv URLs, physics briefings, and journal publications
  * Standardized search result count field naming across API responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->