### PR TITLE
feat: stricter enums and improved error message handling with verbosity

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,13 @@ validation error.
 
 ::: stare.models.enums.PaperStatus
 
-::: stare.models.enums.PhaseState
+::: stare.models.enums.Phase0State
+
+::: stare.models.enums.Phase1State
+
+::: stare.models.enums.Phase2State
+
+::: stare.models.enums.SubmissionState
 
 ::: stare.models.enums.CollisionType
 

--- a/src/stare/cli/__init__.py
+++ b/src/stare/cli/__init__.py
@@ -78,6 +78,14 @@ def conf_note(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Fetch a single CONF note by temporary reference code via GET /confnotes/{ref_code}.
 
@@ -92,7 +100,7 @@ def conf_note(
         output_json = not stdout_is_interactive()
     g = utils.make_glance(no_cache=no_cache)
     try:
-        result = g.conf_notes.get(ref_code)
+        result = g.conf_notes.get(ref_code, verbose=verbose)
     except StareError as exc:
         utils.handle_error(exc)
         raise typer.Exit(1) from exc
@@ -129,6 +137,14 @@ def pub_note(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Fetch a single PUB note by temporary reference code via GET /pubnotes/{ref_code}.
 
@@ -143,7 +159,7 @@ def pub_note(
         output_json = not stdout_is_interactive()
     g = utils.make_glance(no_cache=no_cache)
     try:
-        result = g.pub_notes.get(ref_code)
+        result = g.pub_notes.get(ref_code, verbose=verbose)
     except StareError as exc:
         utils.handle_error(exc)
         raise typer.Exit(1) from exc

--- a/src/stare/cli/analysis.py
+++ b/src/stare/cli/analysis.py
@@ -66,6 +66,14 @@ def analysis_search(
             help="Validate and normalize the query string (default: on).",
         ),
     ] = True,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Search analyses via GET /searchAnalysis.
 
@@ -93,6 +101,7 @@ def analysis_search(
             sort_by=sort_by,
             sort_desc=sort_desc,
             validate_query=validate,
+            verbose=verbose,
         )
     except DSLError as exc:
         raise typer.BadParameter(str(exc), param_hint="--query") from exc
@@ -134,6 +143,14 @@ def analysis_get(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Fetch a single analysis by reference code via GET /analyses/{ref_code}.
 
@@ -148,7 +165,7 @@ def analysis_get(
         output_json = not stdout_is_interactive()
     g = utils.make_glance(no_cache=no_cache)
     try:
-        result = g.analyses.get(ref_code)
+        result = g.analyses.get(ref_code, verbose=verbose)
     except StareError as exc:
         utils.handle_error(exc)
         raise typer.Exit(1) from exc

--- a/src/stare/cli/paper.py
+++ b/src/stare/cli/paper.py
@@ -66,6 +66,14 @@ def paper_search(
             help="Validate and normalize the query string (default: on).",
         ),
     ] = True,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Search papers via GET /searchPaper.
 
@@ -92,6 +100,7 @@ def paper_search(
             sort_by=sort_by,
             sort_desc=sort_desc,
             validate_query=validate,
+            verbose=verbose,
         )
     except DSLError as exc:
         raise typer.BadParameter(str(exc), param_hint="--query") from exc
@@ -133,6 +142,14 @@ def paper_get(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Fetch a single paper by reference code via GET /papers/{ref_code}.
 
@@ -147,7 +164,7 @@ def paper_get(
         output_json = not stdout_is_interactive()
     g = utils.make_glance(no_cache=no_cache)
     try:
-        result = g.papers.get(ref_code)
+        result = g.papers.get(ref_code, verbose=verbose)
     except StareError as exc:
         utils.handle_error(exc)
         raise typer.Exit(1) from exc

--- a/src/stare/cli/publications.py
+++ b/src/stare/cli/publications.py
@@ -46,6 +46,14 @@ def publications_search(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Search across all publication types via GET /publications/search.
 
@@ -68,6 +76,7 @@ def publications_search(
             leading_groups=leading_group or None,
             subgroups=subgroup or None,
             statuses=status or None,
+            verbose=verbose,
         )
     except StareError as exc:
         utils.handle_error(exc)

--- a/src/stare/cli/triggers.py
+++ b/src/stare/cli/triggers.py
@@ -34,6 +34,14 @@ def triggers_search(
         bool,
         typer.Option("--no-cache", help="Bypass the HTTP cache for this invocation."),
     ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Attach the full raw API response to parse errors (useful for debugging).",
+        ),
+    ] = False,
 ) -> None:
     """Search HLT triggers via GET /triggers/search.
 
@@ -51,6 +59,7 @@ def triggers_search(
         results = g.triggers.search(
             categories=category or None,
             years=year or None,
+            verbose=verbose,
         )
     except StareError as exc:
         utils.handle_error(exc)

--- a/src/stare/cli/utils.py
+++ b/src/stare/cli/utils.py
@@ -28,9 +28,30 @@ def sizeof_fmt(num: float, suffix: str = "B") -> str:
 
 
 def handle_error(exc: StareError) -> None:
-    """Print a StareError to stderr; for ResponseParseError also show the raw JSON."""
+    """Print a StareError to stderr.
+
+    For ResponseParseError, render one rich.json.JSON panel per enriched
+    detail (titled with the failing location and parent-object context), and
+    additionally render the full raw API response when it was attached
+    (i.e. the caller passed verbose=True to model_validate).
+    """
     err_console.print(f"[red]Error:[/red] {exc}")
-    if isinstance(exc, ResponseParseError) and exc.raw_data is not None:
+    if not isinstance(exc, ResponseParseError):
+        return
+    for i, detail in enumerate(exc.details, 1):
+        if detail.snippet is None:
+            continue
+        title = f"{i}. {detail.loc_str}"
+        if detail.context:
+            title = f"{title} — {detail.context}"
+        err_console.print(
+            Panel(
+                JSON(json.dumps(detail.snippet, default=str)),
+                title=f"[yellow]{title}[/yellow]",
+                border_style="yellow",
+            )
+        )
+    if exc.raw_data is not None:
         err_console.print(
             Panel(
                 JSON(json.dumps(exc.raw_data, default=str)),

--- a/src/stare/client.py
+++ b/src/stare/client.py
@@ -217,7 +217,10 @@ class PublicationResource:
         params += [("statuses", val) for val in statuses or []]
         response = self._client.get("/publications/search", params=params)
         _raise_for_status(response)
-        return [PublicationRef.model_validate(item, verbose=verbose) for item in response.json()]
+        return [
+            PublicationRef.model_validate(item, verbose=verbose)
+            for item in response.json()
+        ]
 
 
 class GroupResource:
@@ -274,7 +277,9 @@ class TriggerResource:
         params += [("years", val) for val in years or []]
         response = self._client.get("/triggers/search", params=params)
         _raise_for_status(response)
-        return [Trigger.model_validate(item, verbose=verbose) for item in response.json()]
+        return [
+            Trigger.model_validate(item, verbose=verbose) for item in response.json()
+        ]
 
 
 class Glance:

--- a/src/stare/client.py
+++ b/src/stare/client.py
@@ -92,11 +92,11 @@ class AnalysisResource:
         """Store the shared httpx client."""
         self._client = client
 
-    def get(self, ref_code: str) -> Analysis:
+    def get(self, ref_code: str, *, verbose: bool = False) -> Analysis:
         """Fetch a single analysis by reference code."""
         response = self._client.get(f"/analyses/{ref_code}")
         _raise_for_status(response)
-        return Analysis.model_validate(response.json())
+        return Analysis.model_validate(response.json(), verbose=verbose)
 
     def search(
         self,
@@ -107,6 +107,7 @@ class AnalysisResource:
         sort_by: str | None = None,
         sort_desc: bool = False,
         validate_query: bool = True,
+        verbose: bool = False,
     ) -> AnalysisSearchResult:
         """Search analyses via GET /searchAnalysis."""
         params: dict[str, Any] = {"offset": offset, "limit": limit}
@@ -119,7 +120,7 @@ class AnalysisResource:
             params["sortDesc"] = str(sort_desc).lower()
         response = self._client.get("/searchAnalysis", params=params)
         _raise_for_status(response)
-        return AnalysisSearchResult.model_validate(response.json())
+        return AnalysisSearchResult.model_validate(response.json(), verbose=verbose)
 
 
 class PaperResource:
@@ -129,11 +130,11 @@ class PaperResource:
         """Store the shared httpx client."""
         self._client = client
 
-    def get(self, ref_code: str) -> Paper:
+    def get(self, ref_code: str, *, verbose: bool = False) -> Paper:
         """Fetch a single paper by reference code."""
         response = self._client.get(f"/papers/{ref_code}")
         _raise_for_status(response)
-        return Paper.model_validate(response.json())
+        return Paper.model_validate(response.json(), verbose=verbose)
 
     def search(
         self,
@@ -144,6 +145,7 @@ class PaperResource:
         sort_by: str | None = None,
         sort_desc: bool = False,
         validate_query: bool = True,
+        verbose: bool = False,
     ) -> PaperSearchResult:
         """Search papers via GET /searchPaper."""
         params: dict[str, Any] = {"offset": offset, "limit": limit}
@@ -156,7 +158,7 @@ class PaperResource:
             params["sortDesc"] = str(sort_desc).lower()
         response = self._client.get("/searchPaper", params=params)
         _raise_for_status(response)
-        return PaperSearchResult.model_validate(response.json())
+        return PaperSearchResult.model_validate(response.json(), verbose=verbose)
 
 
 class ConfNoteResource:
@@ -166,11 +168,11 @@ class ConfNoteResource:
         """Store the shared httpx client."""
         self._client = client
 
-    def get(self, temp_ref_code: str) -> ConfNote:
+    def get(self, temp_ref_code: str, *, verbose: bool = False) -> ConfNote:
         """Fetch a single CONF note by temporary reference code."""
         response = self._client.get(f"/confnotes/{temp_ref_code}")
         _raise_for_status(response)
-        return ConfNote.model_validate(response.json())
+        return ConfNote.model_validate(response.json(), verbose=verbose)
 
 
 class PubNoteResource:
@@ -180,11 +182,11 @@ class PubNoteResource:
         """Store the shared httpx client."""
         self._client = client
 
-    def get(self, temp_ref_code: str) -> PubNote:
+    def get(self, temp_ref_code: str, *, verbose: bool = False) -> PubNote:
         """Fetch a single PUB note by temporary reference code."""
         response = self._client.get(f"/pubnotes/{temp_ref_code}")
         _raise_for_status(response)
-        return PubNote.model_validate(response.json())
+        return PubNote.model_validate(response.json(), verbose=verbose)
 
 
 class PublicationResource:
@@ -203,6 +205,7 @@ class PublicationResource:
         leading_groups: list[str] | None = None,
         subgroups: list[str] | None = None,
         statuses: list[str] | None = None,
+        verbose: bool = False,
     ) -> list[PublicationRef]:
         """Search across all publication types."""
         params: list[tuple[str, str | int | float | bool | None]] = []
@@ -214,7 +217,7 @@ class PublicationResource:
         params += [("statuses", val) for val in statuses or []]
         response = self._client.get("/publications/search", params=params)
         _raise_for_status(response)
-        return [PublicationRef.model_validate(item) for item in response.json()]
+        return [PublicationRef.model_validate(item, verbose=verbose) for item in response.json()]
 
 
 class GroupResource:
@@ -263,6 +266,7 @@ class TriggerResource:
         *,
         categories: list[str] | None = None,
         years: list[str] | None = None,
+        verbose: bool = False,
     ) -> list[Trigger]:
         """Search triggers by category and/or year."""
         params: list[tuple[str, str | int | float | bool | None]] = []
@@ -270,7 +274,7 @@ class TriggerResource:
         params += [("years", val) for val in years or []]
         response = self._client.get("/triggers/search", params=params)
         _raise_for_status(response)
-        return [Trigger.model_validate(item) for item in response.json()]
+        return [Trigger.model_validate(item, verbose=verbose) for item in response.json()]
 
 
 class Glance:

--- a/src/stare/exceptions.py
+++ b/src/stare/exceptions.py
@@ -4,8 +4,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from typing import Any
+
+
+class EnrichedErrorResponse(BaseModel):
+    loc: tuple[int | str, ...]
+    loc_str: str
+    message: str
+    context: str | None = None
+    snippet: object | None = None
+    input_val: object | None = None
 
 
 class StareError(Exception):
@@ -52,7 +63,13 @@ class ResponseParseError(StareError):
             error message.
     """
 
-    def __init__(self, message: str, raw_data: Any = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        raw_data: Any = None,
+        details: list[EnrichedErrorResponse] | None = None,
+    ) -> None:
         """Store the raw API payload alongside the error message."""
         self.raw_data = raw_data
+        self.details = details or []
         super().__init__(message)

--- a/src/stare/exceptions.py
+++ b/src/stare/exceptions.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
 
 
 class EnrichedErrorResponse(BaseModel):
+    """Structured representation of a single pydantic validation error with context."""
+
     loc: tuple[int | str, ...]
     loc_str: str
     message: str

--- a/src/stare/models/__init__.py
+++ b/src/stare/models/__init__.py
@@ -27,9 +27,12 @@ from stare.models.enums import (
     CollisionType,
     MeetingType,
     PaperStatus,
-    PhaseState,
+    Phase0State,
+    Phase1State,
+    Phase2State,
     PublicationType,
     RepositoryType,
+    SubmissionState,
 )
 from stare.models.errors import ApiErrorResponse
 from stare.models.paper import Paper, PaperPhase1, PaperPhase2, SubmissionPhase
@@ -69,7 +72,9 @@ __all__ = [
     "PaperSearchResult",
     "PaperStatus",
     "Person",
-    "PhaseState",
+    "Phase0State",
+    "Phase1State",
+    "Phase2State",
     "PubNote",
     "PubNotePhase1",
     "PubNoteReader",
@@ -79,6 +84,7 @@ __all__ = [
     "Repository",
     "RepositoryType",
     "SubmissionPhase",
+    "SubmissionState",
     "TeamMember",
     "TokenInfo",
     "Trigger",

--- a/src/stare/models/analysis.py
+++ b/src/stare/models/analysis.py
@@ -20,7 +20,7 @@ from stare.models.common import (
     TypedMeeting,
     _Base,
 )
-from stare.models.enums import LenientAnalysisStatus, LenientPhaseState, MeetingType
+from stare.models.enums import AnalysisStatus, MeetingType, Phase0State
 
 _logger = logging.getLogger("stare")
 
@@ -43,7 +43,7 @@ class AnalysisPhase0(_Base):
     Serialization restores the original four keys for API round-trip fidelity.
     """
 
-    state: LenientPhaseState | None = None
+    state: Phase0State | None = None
     start_date: date | None = None
     main_physics_aim: str | None = None
     dataset_used: str | None = None
@@ -99,7 +99,7 @@ class Analysis(_Base):
 
     reference_code: str | None = None
     creation_date: date | None = None
-    status: LenientAnalysisStatus | None = None
+    status: AnalysisStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     groups: Groups | None = None

--- a/src/stare/models/analysis.py
+++ b/src/stare/models/analysis.py
@@ -21,9 +21,9 @@ from stare.models.common import (
     _Base,
 )
 from stare.models.enums import (
-    MeetingType,
     LenientAnalysisStatus,
     LenientPhase0State,
+    MeetingType,
 )
 
 _logger = logging.getLogger("stare")

--- a/src/stare/models/analysis.py
+++ b/src/stare/models/analysis.py
@@ -20,7 +20,11 @@ from stare.models.common import (
     TypedMeeting,
     _Base,
 )
-from stare.models.enums import AnalysisStatus, MeetingType, Phase0State
+from stare.models.enums import (
+    MeetingType,
+    LenientAnalysisStatus,
+    LenientPhase0State,
+)
 
 _logger = logging.getLogger("stare")
 
@@ -43,7 +47,7 @@ class AnalysisPhase0(_Base):
     Serialization restores the original four keys for API round-trip fidelity.
     """
 
-    state: Phase0State | None = None
+    state: LenientPhase0State | None = None
     start_date: date | None = None
     main_physics_aim: str | None = None
     dataset_used: str | None = None
@@ -99,7 +103,7 @@ class Analysis(_Base):
 
     reference_code: str | None = None
     creation_date: date | None = None
-    status: AnalysisStatus | None = None
+    status: LenientAnalysisStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     groups: Groups | None = None

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_valida
 from pydantic.alias_generators import to_camel
 from rich.text import Text
 
-from stare.exceptions import ResponseParseError
+from stare.exceptions import EnrichedErrorResponse, ResponseParseError
 from stare.models.enums import (
     LenientCollisionType,
     LenientPublicationType,
@@ -46,18 +46,65 @@ def _extract_context(obj: Any, loc: tuple[str | int, ...]) -> str | None:
         node = obj
         for part in loc[:-1]:
             node = node[part]
-        if isinstance(node, dict):
-            ref = node.get("referenceCode")
-            if ref:
-                return f"referenceCode={ref!r}"
+            if isinstance(node, dict):
+                ref = node.get("referenceCode")
+                if ref:
+                    return f"referenceCode={ref!r}"
     except (KeyError, IndexError, TypeError):
         pass
     return None
 
 
+def _truncate_with_focus(
+    obj: Any, loc: tuple[str | int, ...], max_list: int = 5
+) -> Any:
+    """Return a truncated version of obj focused on the failing location."""
+    if not loc:
+        return obj
+
+    head, *tail = loc
+
+    if isinstance(obj, list) and isinstance(head, int):
+        idx = head
+        n = len(obj)
+
+        # Determine window around the failing index
+        start = max(0, idx - max_list // 2)
+        end = min(n, idx + max_list // 2 + 1)
+
+        truncated = []
+
+        if start > 0:
+            truncated.append(f"... {start} items ...")
+
+        for i in range(start, end):
+            if i == idx:
+                truncated.append(_truncate_with_focus(obj[i], tuple(tail), max_list))
+            else:
+                truncated.append("{...}")
+
+        if end < n:
+            truncated.append(f"... {n - end} more items ...")
+
+        return truncated
+
+    if isinstance(obj, dict) and isinstance(head, str):
+        result = {}
+
+        for k, v in obj.items():
+            if k == head:
+                result[k] = _truncate_with_focus(v, tuple(tail), max_list)
+            else:
+                result[k] = "{...}"
+
+        return result
+
+    return obj
+
+
 def _format_parse_error(
     model_name: str, error: ValidationError, obj: Any = None
-) -> str:
+) -> tuple[str, list[EnrichedErrorResponse]]:
     """Build a human-readable summary of a pydantic ValidationError.
 
     For scalar inputs the offending value is shown inline; complex inputs
@@ -72,6 +119,8 @@ def _format_parse_error(
     lines = [
         f"Failed to parse {model_name} from API response ({count} validation error(s)):"
     ]
+    enriched_errors = []
+
     for i, err in enumerate(errors, 1):
         loc_tuple: tuple[str | int, ...] = err.get("loc", ())
         loc = _format_loc(loc_tuple)
@@ -80,11 +129,27 @@ def _format_parse_error(
         context = _extract_context(obj, loc_tuple) if obj is not None else None
         line = f"  {i}. {loc}: {msg}"
         if context:
-            line += f" [{context}]"
+            line += f" ({context})"
         if input_val is not None and not isinstance(input_val, dict | list):
-            line += f" [got: {type(input_val).__name__} = {input_val!r}]"
+            line += f" (got: {type(input_val).__name__} = {input_val!r})"
         lines.append(line)
-    return "\n".join(lines)
+
+        snippet = _truncate_with_focus(obj, loc_tuple) if obj is not None else None
+
+        enriched_errors.append(
+            EnrichedErrorResponse.model_validate(
+                {
+                    "loc": loc_tuple,
+                    "loc_str": loc,
+                    "message": msg,
+                    "context": context,
+                    "snippet": snippet,
+                    "input_val": input_val,
+                }
+            )
+        )
+
+    return "\n".join(lines), enriched_errors
 
 
 class _Base(BaseModel):
@@ -98,13 +163,18 @@ class _Base(BaseModel):
         cls,
         obj: Any,
         *args: Any,
+        verbose: bool = False,
         **kwargs: Any,
     ) -> Self:
         try:
             return super().model_validate(obj, *args, **kwargs)
         except ValidationError as exc:
+            msg, details = _format_parse_error(cls.__name__, exc, obj=obj)
+
             raise ResponseParseError(
-                _format_parse_error(cls.__name__, exc, obj=obj), raw_data=obj
+                msg,
+                raw_data=obj if verbose else None,
+                details=details,
             ) from exc
 
 

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -11,10 +11,10 @@ from rich.text import Text
 
 from stare.exceptions import EnrichedErrorResponse, ResponseParseError
 from stare.models.enums import (
-    CollisionType,
+    LenientCollisionType,
+    LenientPublicationType,
+    LenientRepositoryType,
     MeetingType,
-    PublicationType,
-    RepositoryType,
 )
 
 if TYPE_CHECKING:
@@ -237,7 +237,7 @@ class Groups(_Base):
 class Collision(_Base):
     """A collision dataset descriptor (centre-of-mass energy, luminosity, etc.)."""
 
-    type: CollisionType | None = None
+    type: LenientCollisionType | None = None
     year: str | None = None
     run: str | None = None
     ecm_value: str | None = None
@@ -267,7 +267,7 @@ class Repository(Link):
     """A code or documentation repository."""
 
     gitlab_id: str | None = None
-    type: RepositoryType | None = None
+    type: LenientRepositoryType | None = None
 
 
 class Documentation(_Base):
@@ -313,4 +313,4 @@ class RelatedPublication(_Base):
     """A reference to a related publication (analysis, paper, CONF/PUB note)."""
 
     reference_code: str | None = None
-    type: PublicationType | None = None
+    type: LenientPublicationType | None = None

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -11,10 +11,10 @@ from rich.text import Text
 
 from stare.exceptions import EnrichedErrorResponse, ResponseParseError
 from stare.models.enums import (
-    LenientCollisionType,
-    LenientPublicationType,
-    LenientRepositoryType,
+    CollisionType,
     MeetingType,
+    PublicationType,
+    RepositoryType,
 )
 
 if TYPE_CHECKING:
@@ -237,7 +237,7 @@ class Groups(_Base):
 class Collision(_Base):
     """A collision dataset descriptor (centre-of-mass energy, luminosity, etc.)."""
 
-    type: LenientCollisionType | None = None
+    type: CollisionType | None = None
     year: str | None = None
     run: str | None = None
     ecm_value: str | None = None
@@ -267,7 +267,7 @@ class Repository(Link):
     """A code or documentation repository."""
 
     gitlab_id: str | None = None
-    type: LenientRepositoryType | None = None
+    type: RepositoryType | None = None
 
 
 class Documentation(_Base):
@@ -313,4 +313,4 @@ class RelatedPublication(_Base):
     """A reference to a related publication (analysis, paper, CONF/PUB note)."""
 
     reference_code: str | None = None
-    type: LenientPublicationType | None = None
+    type: PublicationType | None = None

--- a/src/stare/models/conf_note.py
+++ b/src/stare/models/conf_note.py
@@ -15,7 +15,7 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import LenientPaperStatus, LenientPhaseState
+from stare.models.enums import PaperStatus, Phase1State
 
 
 class _SignOffResponsible(_Base):
@@ -28,7 +28,7 @@ class _SignOffResponsible(_Base):
 class ConfNotePhase1(_Base):
     """Phase 1 lifecycle metadata for a CONF note."""
 
-    state: LenientPhaseState | None = None
+    state: Phase1State | None = None
     start_date: date | None = None
     cds_url: str | None = Field(default=None, alias="cdsDraftNoteUrl")
     editorial_board: list[EditorialBoardMember] = Field(default_factory=list)
@@ -56,7 +56,7 @@ class ConfNote(_Base):
     temp_reference_code: str | None = Field(
         default=None, alias="temporaryReferenceCode"
     )
-    status: LenientPaperStatus | None = None
+    status: PaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/conf_note.py
+++ b/src/stare/models/conf_note.py
@@ -15,7 +15,7 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import PaperStatus, Phase1State
+from stare.models.enums import LenientPaperStatus, LenientPhase1State
 
 
 class _SignOffResponsible(_Base):
@@ -28,7 +28,7 @@ class _SignOffResponsible(_Base):
 class ConfNotePhase1(_Base):
     """Phase 1 lifecycle metadata for a CONF note."""
 
-    state: Phase1State | None = None
+    state: LenientPhase1State | None = None
     start_date: date | None = None
     cds_url: str | None = Field(default=None, alias="cdsDraftNoteUrl")
     editorial_board: list[EditorialBoardMember] = Field(default_factory=list)
@@ -56,7 +56,7 @@ class ConfNote(_Base):
     temp_reference_code: str | None = Field(
         default=None, alias="temporaryReferenceCode"
     )
-    status: PaperStatus | None = None
+    status: LenientPaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -7,12 +7,37 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
+from typing import Annotated, Any, TypeVar
+
+from pydantic import BeforeValidator
 
 _logger = logging.getLogger("stare")
+
+_E = TypeVar("_E", bound="StrEnum")
 
 
 class StrEnum(str, Enum):
     """Python 3.10-compatible string enum base (StrEnum was added in 3.11)."""
+
+
+def _lenient(enum_cls: type[_E]) -> Any:
+    """Return ``Annotated[EnumCls | str, BeforeValidator]`` for use in model fields.
+
+    Unknown string values fall back to the raw string and log a warning.
+    """
+
+    def _validate(v: object) -> object:
+        if not isinstance(v, str):
+            return v
+        try:
+            return enum_cls(v)
+        except ValueError:
+            _logger.warning(
+                "Unknown %s value %r — storing as raw string", enum_cls.__name__, v
+            )
+            return v
+
+    return Annotated[enum_cls | str, BeforeValidator(_validate)]
 
 
 class MeetingType(StrEnum):
@@ -153,3 +178,15 @@ class PublicationType(StrEnum):
     CONF_NOTE = "ConfNote"
     PUB_NOTE = "PubNote"
     ANALYSIS = "Analysis"
+
+
+LenientMeetingType = _lenient(MeetingType)
+LenientAnalysisStatus = _lenient(AnalysisStatus)
+LenientPaperStatus = _lenient(PaperStatus)
+LenientPhase0State = _lenient(Phase0State)
+LenientPhase1State = _lenient(Phase1State)
+LenientPhase2State = _lenient(Phase2State)
+LenientSubmissionState = _lenient(SubmissionState)
+LenientCollisionType = _lenient(CollisionType)
+LenientRepositoryType = _lenient(RepositoryType)
+LenientPublicationType = _lenient(PublicationType)

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -95,6 +95,9 @@ class Phase0State(StrEnum):
     PAPER_SKIP = "Skipped to Paper"
     CONF_SKIP = "Skipped to CONF Note"
     PUB_SKIP = "Skipped to PUB Note"
+    CONF_CONTACT_EDITORS = "conf_contact_editors_definition"
+    PUB_CONTACT_EDITORS = "pub_contact_editors_definition"
+    PAPER_CONTACT_EDITORS = "paper_contact_editors_definition"
 
 
 class Phase1State(StrEnum):

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -7,37 +7,12 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
-from typing import Annotated, Any, TypeVar
-
-from pydantic import BeforeValidator
 
 _logger = logging.getLogger("stare")
-
-_E = TypeVar("_E", bound="StrEnum")
 
 
 class StrEnum(str, Enum):
     """Python 3.10-compatible string enum base (StrEnum was added in 3.11)."""
-
-
-def _lenient(enum_cls: type[_E]) -> Any:
-    """Return ``Annotated[EnumCls | str, BeforeValidator]`` for use in model fields.
-
-    Unknown string values fall back to the raw string and log a warning.
-    """
-
-    def _validate(v: object) -> object:
-        if not isinstance(v, str):
-            return v
-        try:
-            return enum_cls(v)
-        except ValueError:
-            _logger.warning(
-                "Unknown %s value %r — storing as raw string", enum_cls.__name__, v
-            )
-            return v
-
-    return Annotated[enum_cls | str, BeforeValidator(_validate)]
 
 
 class MeetingType(StrEnum):
@@ -162,13 +137,13 @@ class CollisionType(StrEnum):
 class RepositoryType(StrEnum):
     """Observed repository type values."""
 
-    ANALYSIS = "analysis"
+    # ANALYSIS = "analysis"
     CONF = "CONF"
-    FRAMEWORK = "framework"
+    # FRAMEWORK = "framework"
     INT = "INT"
     PAP = "PAP"
     PUB = "PUB"
-    THESIS = "thesis"
+    # THESIS = "thesis"
 
 
 class PublicationType(StrEnum):
@@ -178,8 +153,3 @@ class PublicationType(StrEnum):
     CONF_NOTE = "ConfNote"
     PUB_NOTE = "PubNote"
     ANALYSIS = "Analysis"
-
-
-LenientCollisionType = _lenient(CollisionType)
-LenientRepositoryType = _lenient(RepositoryType)
-LenientPublicationType = _lenient(PublicationType)

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -64,14 +64,14 @@ class AnalysisStatus(StrEnum):
 class PaperStatus(StrEnum):
     """Observed status values for Paper, ConfNote, and PubNote records."""
 
-    CREATED = "Not Started"
-    ANALYSIS_CLOSED = "Closed"
+    NOT_STARTED = "Not Started"
+    CLOSED = "Closed"
     PHASE1_ACTIVE = "Phase 1 Active"
     PHASE1_CLOSED = "Phase 1 Closed"
     PHASE2_ACTIVE = "Phase 2 Active"
     PHASE2_CLOSED = "Phase 2 Closed"
     SUBMISSION_ACTIVE = "Publication Phase Active"
-    SUBMISSION_CLOSED = "Completed"
+    SUBMISSION_COMPLETED = "Completed"
 
 
 class Phase0State(StrEnum):

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -1,9 +1,6 @@
 """Semantic string enums for Glance API fields.
 
 Each public enum documents the known value set for a field.
-All enums are exposed in their "lenient" form via the ``Lenient*`` type
-aliases, which accept unknown strings gracefully (logging a warning)
-rather than raising a validation error.
 """
 
 from __future__ import annotations
@@ -55,9 +52,8 @@ class MeetingType(StrEnum):
 class AnalysisStatus(StrEnum):
     """Observed status values for Analysis records."""
 
-    ACTIVE = "Active"
-    ANALYSIS_CLOSED = "Analysis Closed"
     CREATED = "Created"
+    ANALYSIS_CLOSED = "Analysis Closed"
     PHASE0_ACTIVE = "Phase 0 Active"
     PHASE0_CLOSED = "Phase 0 Closed"
 
@@ -65,46 +61,84 @@ class AnalysisStatus(StrEnum):
 class PaperStatus(StrEnum):
     """Observed status values for Paper, ConfNote, and PubNote records."""
 
-    ANALYSIS_CLOSED = "Analysis Closed"
-    CREATED = "Created"
+    CREATED = "Not Started"
+    ANALYSIS_CLOSED = "Closed"
     PHASE1_ACTIVE = "Phase 1 Active"
-    PHASE2_ACTIVE = "Phase 2 Active"
-    SUBMISSION_ACTIVE = "Submission Active"
-    SUBMISSION_CLOSED = "Submission Closed"
-    ACTIVE = "Active"
+    PHASE1_CLOSED = "Phase 1 Closed"
+    PHASE3_ACTIVE = "Phase 2 Active"
+    PHASE3_CLOSED = "Phase 2 Closed"
+    SUBMISSION_ACTIVE = "Publication Phase Active"
+    SUBMISSION_CLOSED = "Completed"
 
 
-class PhaseState(StrEnum):
-    """Observed workflow state keys for phase0/phase1/phase2/submission phases."""
+class Phase0State(StrEnum):
+    """Observed workflow state keys for phase0 phase."""
 
-    # Human-readable states seen in test data
-    ACTIVE = "Active"
-    APPROVED = "Approved"
-    FINAL_REVIEW_CLOSED = "final_review_closed"
-    FINISHED = "finished"
-    REVIEW_CLOSED = "review_closed"
-    # Internal workflow state identifiers seen in live API
-    ANALYSIS_COORDINATORS_SELECTION = "analysis_coordinators_selection"
-    ANALYSIS_COORDINATORS_TIMELINE = "analysis_coordinators_timeline"
-    ANALYSIS_DEFINITION = "analysis_definition"
-    APPROVED_BY_REVIEWER = "approved_by_reviewer"
-    APPROVAL_ACCEPTANCE = "approval_acceptance"
-    APPROVAL_MEETING = "approval_meeting_data"
-    EDBOARD_MEETING = "edboard_meeting_data"
-    EDBOARD_REQUEST_MEETING = "edboard_request_meeting_data"
-    CONF_SKIP = "conf_skip"
-    EOI_MEETING = "eoi_meeting"
-    FIRST_ANALYSIS = "first_analysis_data"
-    INTERNAL_NOTE = "internal_note_editors_definition"
-    PAPER_CONTACT_EDITORS_DEFINITION = "paper_contact_editors_definition"
-    PAPER_SKIP = "paper_skip"
-    PHASE0_ACTIVE = "phase0_active"
-    PGC_SGC_SIGNOFF = "pgc_sgc_contact_signoff"
-    PRE_APPROVAL_MEETING = "pre_approval_meeting_data"
-    PUBLICATION_DRAFT = "publication_draft"
-    PUB_CONTACT_EDITORS_DEFINITION = "pub_contact_editors_definition"
-    PUB_SKIP = "pub_skip"
-    SECOND_ANALYSIS = "second_analysis_data"
+    NOT_STARTED = "Phase 0 Data"
+    EOI_MEETING = "Expression of interest (EOI) meeting data"
+    ANALYSIS_DEFINITION = "Analysis definition after EOI meeting"
+    ANALYSIS_COORDINATORS_SELECTION = "Analysis contact and expert review selection"
+    FIRST_ANALYSIS_DATA = "Analysis metadata"
+    ANALYSIS_COORDINATORS_TIMELINE = "Analysis contacts' target date"
+    SECOND_ANALYSIS_DATA = "Auxiliary metadata"
+    INTERNAL_NOTE_EDITORS_DEFINITION = (
+        "Internal note editors and contact editors appointment"
+    )
+    EDBOARD_REQUEST_MEETING_DATA = "Editorial Board request meeting and formation data"
+    EDBOARD_MEETING_DATA = "Editorial Board meeting data"
+    PRE_APPROVAL_MEETING_DATA = "Pre approval meeting data"
+    PGC_SGC_CONTACT_SIGNOFF = "PGC or SGC pre approval sign-off"
+    PUBLICATION_DRAFT = "Publication draft"
+    APPROVAL_MEETING_DATA = "Approval meeting data"
+    APPROVAL_ACCEPTANCE = "Approval acceptance"
+    FINISHED = "Publications definition"
+    PAPER_SKIP = "Skipped to Paper"
+    CONF_SKIP = "Skipped to CONF Note"
+    PUB_SKIP = "Skipped to PUB Note"
+
+
+class Phase1State(StrEnum):
+    """Observed workflow state keys for phase1 phase."""
+
+    NOT_STARTED = "Phase 1 Data"
+    STARTED = "Editorial Board"
+    APPROVED_BY_REVIEWER = "Analysis Review"
+    LGP_APPROVED = "Editorial Board Draft Sign-off"
+    REVIEW_CLOSED = "Draft 1 Released to ATLAS"
+    FINISHED = "Phase Closed"
+
+
+class Phase2State(StrEnum):
+    """Observed workflow state keys for phase2 phase."""
+
+    STARTED = "Phase 2 Data"
+    FINAL_REVIEW_CLOSED = "Draft 2 Approval Process"
+    UPDATE_EDBOARD = "Revised Draft Final Sign-off by Editorial Board Chair"
+    UPDATED_PUBCOMM = (
+        "Revised Draft Final Sign-off by Publication Committee Chair or Deputy"
+    )
+    UPDATED_SPOKESPERSONDATE = "Final Sign-off by Spokesperson or Deputy"
+    FINISHED = "Phase Closed"
+
+
+class SubmissionState(StrEnum):
+    """Observed workflow state keys for submission phase."""
+
+    NOT_STARTED = "Publication Phase Launch"
+    STARTED = "Tarball Receiving"
+    TARBALL_RECEIVED = "CERN and ATLAS Collection"
+    SUBMITTED_TO_ARXIV = "Journal Submission"
+    SUBMITTED_TO_JOURNAL = "Journal Reports Receiving"
+    JOURNAL_REPORT_RECEIVED = "Journal Reports Answering"
+    JOURNAL_REPORT_ANSWERED = "Journal Acceptance"
+    ACCEPTED_BY_JOURNAL = "Proofs Receiving"
+    PROOFS_RECEIVED = "Proofs Answering"
+    PROOF_ANSWERED = "Online Publication"
+    PUBLISHED_ONLINE = "Final ArXiv Replacement"
+    ERRATUM_REQUESTED = "Erratum Submission"
+    ERRATUM_SUBMITTED = "Erratum Acceptance"
+    FINAL_ARXIV_REPLACED = "Paper Finish"
+    FINISHED = "Submission Closed"
 
 
 class CollisionType(StrEnum):
@@ -112,11 +146,14 @@ class CollisionType(StrEnum):
 
     PP = "p-p"
     P_PB = "p-Pb"
-    PBPB = "Pb-Pb"
+    PB_PB = "Pb-Pb"
     XE_XE = "Xe-Xe"
     COL_TYPE = "Col type"
     SEC_COL_TYPE = "Sec col type"
     TERT_COL_TYPE = "Tert col type"
+    NE_NE = "NeNe"
+    O_O = "OO"
+    P_O = "pO"
 
 
 class RepositoryType(StrEnum):
@@ -140,10 +177,6 @@ class PublicationType(StrEnum):
     ANALYSIS = "Analysis"
 
 
-# Lenient type aliases — use these in model field annotations.
-LenientAnalysisStatus = _lenient(AnalysisStatus)
-LenientPaperStatus = _lenient(PaperStatus)
-LenientPhaseState = _lenient(PhaseState)
 LenientCollisionType = _lenient(CollisionType)
 LenientRepositoryType = _lenient(RepositoryType)
 LenientPublicationType = _lenient(PublicationType)

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -165,13 +165,10 @@ class CollisionType(StrEnum):
 class RepositoryType(StrEnum):
     """Observed repository type values."""
 
-    # ANALYSIS = "analysis"
     CONF = "CONF"
-    # FRAMEWORK = "framework"
     INT = "INT"
     PAP = "PAP"
     PUB = "PUB"
-    # THESIS = "thesis"
 
 
 class PublicationType(StrEnum):

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -185,8 +185,6 @@ class PublicationType(StrEnum):
 
 # Lenient type aliases — use these in model field annotations.
 LenientMeetingType = _lenient(MeetingType)
-LenientAnalysisStatus = _lenient(AnalysisStatus)
-LenientPaperStatus = _lenient(PaperStatus)
 LenientPhase0State = _lenient(Phase0State)
 LenientPhase1State = _lenient(Phase1State)
 LenientPhase2State = _lenient(Phase2State)

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -68,8 +68,8 @@ class PaperStatus(StrEnum):
     ANALYSIS_CLOSED = "Closed"
     PHASE1_ACTIVE = "Phase 1 Active"
     PHASE1_CLOSED = "Phase 1 Closed"
-    PHASE3_ACTIVE = "Phase 2 Active"
-    PHASE3_CLOSED = "Phase 2 Closed"
+    PHASE2_ACTIVE = "Phase 2 Active"
+    PHASE2_CLOSED = "Phase 2 Closed"
     SUBMISSION_ACTIVE = "Publication Phase Active"
     SUBMISSION_CLOSED = "Completed"
 

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -1,6 +1,9 @@
 """Semantic string enums for Glance API fields.
 
 Each public enum documents the known value set for a field.
+All enums are exposed in their "lenient" form via the ``Lenient*`` type
+aliases, which accept unknown strings gracefully (logging a warning)
+rather than raising a validation error.
 """
 
 from __future__ import annotations
@@ -180,6 +183,7 @@ class PublicationType(StrEnum):
     ANALYSIS = "Analysis"
 
 
+# Lenient type aliases — use these in model field annotations.
 LenientMeetingType = _lenient(MeetingType)
 LenientAnalysisStatus = _lenient(AnalysisStatus)
 LenientPaperStatus = _lenient(PaperStatus)
@@ -187,6 +191,8 @@ LenientPhase0State = _lenient(Phase0State)
 LenientPhase1State = _lenient(Phase1State)
 LenientPhase2State = _lenient(Phase2State)
 LenientSubmissionState = _lenient(SubmissionState)
+LenientAnalysisStatus = _lenient(AnalysisStatus)
+LenientPaperStatus = _lenient(PaperStatus)
 LenientCollisionType = _lenient(CollisionType)
 LenientRepositoryType = _lenient(RepositoryType)
 LenientPublicationType = _lenient(PublicationType)

--- a/src/stare/models/paper.py
+++ b/src/stare/models/paper.py
@@ -17,13 +17,18 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import PaperStatus, Phase1State, Phase2State, SubmissionState
+from stare.models.enums import (
+    LenientPaperStatus,
+    LenientPhase1State,
+    LenientPhase2State,
+    LenientSubmissionState,
+)
 
 
 class PaperPhase1(_Base):
     """Phase 1 of the paper lifecycle (review and approval)."""
 
-    state: Phase1State | None = None
+    state: LenientPhase1State | None = None
     start_date: date | None = None
     editorial_board: list[EditorialBoardMember] = Field(default_factory=list)
     editorial_board_formed_on: date | None = None
@@ -51,7 +56,7 @@ class PaperPhase1(_Base):
 class PaperPhase2(_Base):
     """Phase 2 of the paper lifecycle (CERN review, revision, closure)."""
 
-    state: Phase2State | None = None
+    state: LenientPhase2State | None = None
     start_date: date | None = None
     eb_draft2_sign_off_on: date | None = Field(
         default=None, alias="editorialBoardDraft2SignOffOn"
@@ -82,7 +87,7 @@ class PaperPhase2(_Base):
 class SubmissionPhase(_Base):
     """Submission phase: arXiv, journal, final publication."""
 
-    state: SubmissionState | None = None
+    state: LenientSubmissionState | None = None
     start_date: date | None = None
     arxiv_urls: list[Link] = Field(default_factory=list, alias="arXivUrls")
     final_title: str | None = Field(default=None, alias="finalTitleTex")
@@ -115,7 +120,7 @@ class Paper(_Base):
     """A published ATLAS paper."""
 
     reference_code: str | None = None
-    status: PaperStatus | None = None
+    status: LenientPaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/paper.py
+++ b/src/stare/models/paper.py
@@ -17,13 +17,13 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import LenientPaperStatus, LenientPhaseState
+from stare.models.enums import PaperStatus, Phase1State, Phase2State, SubmissionState
 
 
 class PaperPhase1(_Base):
     """Phase 1 of the paper lifecycle (review and approval)."""
 
-    state: LenientPhaseState | None = None
+    state: Phase1State | None = None
     start_date: date | None = None
     editorial_board: list[EditorialBoardMember] = Field(default_factory=list)
     editorial_board_formed_on: date | None = None
@@ -51,7 +51,7 @@ class PaperPhase1(_Base):
 class PaperPhase2(_Base):
     """Phase 2 of the paper lifecycle (CERN review, revision, closure)."""
 
-    state: LenientPhaseState | None = None
+    state: Phase2State | None = None
     start_date: date | None = None
     eb_draft2_sign_off_on: date | None = Field(
         default=None, alias="editorialBoardDraft2SignOffOn"
@@ -82,7 +82,7 @@ class PaperPhase2(_Base):
 class SubmissionPhase(_Base):
     """Submission phase: arXiv, journal, final publication."""
 
-    state: LenientPhaseState | None = None
+    state: SubmissionState | None = None
     start_date: date | None = None
     arxiv_urls: list[Link] = Field(default_factory=list, alias="arXivUrls")
     final_title: str | None = Field(default=None, alias="finalTitleTex")
@@ -115,7 +115,7 @@ class Paper(_Base):
     """A published ATLAS paper."""
 
     reference_code: str | None = None
-    status: LenientPaperStatus | None = None
+    status: PaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/pub_note.py
+++ b/src/stare/models/pub_note.py
@@ -14,7 +14,7 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import LenientPaperStatus, LenientPhaseState
+from stare.models.enums import PaperStatus, Phase1State
 
 
 class PubNoteReader(_Base):
@@ -31,7 +31,7 @@ class PubNoteReader(_Base):
 class PubNotePhase1(_Base):
     """Phase 1 lifecycle metadata for a PUB note."""
 
-    state: LenientPhaseState | None = None
+    state: Phase1State | None = None
     start_date: date | None = None
     draft_cds_url: str | None = Field(default=None, alias="draftNoteCdsUrl")
     readers: list[PubNoteReader] = Field(default_factory=list)
@@ -54,7 +54,7 @@ class PubNote(_Base):
     temp_reference_code: str | None = Field(
         default=None, alias="temporaryReferenceCode"
     )
-    status: LenientPaperStatus | None = None
+    status: PaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/pub_note.py
+++ b/src/stare/models/pub_note.py
@@ -14,7 +14,7 @@ from stare.models.common import (
     TeamMember,
     _Base,
 )
-from stare.models.enums import PaperStatus, Phase1State
+from stare.models.enums import LenientPaperStatus, LenientPhase1State
 
 
 class PubNoteReader(_Base):
@@ -31,7 +31,7 @@ class PubNoteReader(_Base):
 class PubNotePhase1(_Base):
     """Phase 1 lifecycle metadata for a PUB note."""
 
-    state: Phase1State | None = None
+    state: LenientPhase1State | None = None
     start_date: date | None = None
     draft_cds_url: str | None = Field(default=None, alias="draftNoteCdsUrl")
     readers: list[PubNoteReader] = Field(default_factory=list)
@@ -54,7 +54,7 @@ class PubNote(_Base):
     temp_reference_code: str | None = Field(
         default=None, alias="temporaryReferenceCode"
     )
-    status: PaperStatus | None = None
+    status: LenientPaperStatus | None = None
     short_title: str | None = None
     public_short_title: str | None = None
     full_title: str | None = None

--- a/src/stare/models/search.py
+++ b/src/stare/models/search.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 from stare.models.analysis import Analysis
 from stare.models.common import _Base
-from stare.models.enums import PublicationType
+from stare.models.enums import LenientPublicationType
 from stare.models.paper import Paper
 
 T = TypeVar("T")
@@ -33,7 +33,7 @@ class PublicationRef(_Base):
     """A minimal publication reference returned by /publications/search."""
 
     reference_code: str | None = None
-    type: PublicationType | None = None
+    type: LenientPublicationType | None = None
 
 
 class TriggerCategory(_Base):

--- a/src/stare/models/search.py
+++ b/src/stare/models/search.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 from stare.models.analysis import Analysis
 from stare.models.common import _Base
-from stare.models.enums import LenientPublicationType
+from stare.models.enums import PublicationType
 from stare.models.paper import Paper
 
 T = TypeVar("T")
@@ -33,7 +33,7 @@ class PublicationRef(_Base):
     """A minimal publication reference returned by /publications/search."""
 
     reference_code: str | None = None
-    type: LenientPublicationType | None = None
+    type: PublicationType | None = None
 
 
 class TriggerCategory(_Base):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 from stare import __version__
 from stare.cli import app
 from stare.dsl.errors import DSLValidationError
-from stare.exceptions import AuthenticationError, NotFoundError
+from stare.exceptions import AuthenticationError, EnrichedErrorResponse, NotFoundError, ResponseParseError
 from stare.models import (
     Analysis,
     AnalysisSearchResult,
@@ -666,3 +666,60 @@ def test_no_json_paper_search_forces_rich_table() -> None:
         is_json = False
     assert not is_json
     assert "HDBS-2024-01" in result.output
+
+
+# ---------------------------------------------------------------------------
+# ResponseParseError — snippet panels in handle_error
+# ---------------------------------------------------------------------------
+
+
+def _make_parse_error(
+    *,
+    loc_str: str = "results",
+    snippet: object = None,
+    raw_data: object = None,
+) -> ResponseParseError:
+    """Build a ResponseParseError with one enriched detail for testing."""
+    detail = EnrichedErrorResponse(
+        loc=("results",),
+        loc_str=loc_str,
+        message="list type expected",
+        snippet=snippet,
+    )
+    err = ResponseParseError(
+        f"Failed to parse AnalysisSearchResult (1 validation error):\n  1. {loc_str}: list type expected",
+        raw_data=raw_data,
+        details=[detail],
+    )
+    return err
+
+
+def test_analysis_search_prints_snippet_panel_on_parse_error() -> None:
+    """handle_error renders a JSON snippet panel for each enriched detail."""
+    bad_snippet = {"results": "not-a-list"}
+    exc = _make_parse_error(snippet=bad_snippet)
+    mock_g = _mock_glance()
+    mock_g.analyses.search.side_effect = exc
+    with patch("stare.cli.utils.make_glance", return_value=mock_g):
+        result = runner.invoke(app, ["analysis", "search", "--no-json"])
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "validation error" in result.output.lower()
+    # snippet panel title contains the loc_str
+    assert "results" in result.output
+    # snippet body contains the bad value
+    assert "not-a-list" in result.output
+    # raw-response panel not shown without verbose
+    assert "Raw API Response" not in result.output
+
+
+def test_analysis_search_skips_snippet_panel_when_snippet_is_none() -> None:
+    """When detail.snippet is None, no panel is emitted for that detail."""
+    exc = _make_parse_error(snippet=None)
+    mock_g = _mock_glance()
+    mock_g.analyses.search.side_effect = exc
+    with patch("stare.cli.utils.make_glance", return_value=mock_g):
+        result = runner.invoke(app, ["analysis", "search", "--no-json"])
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "Raw API Response" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ runner = CliRunner()
 SAMPLE_ANALYSIS = Analysis.model_validate(
     {
         "referenceCode": "ANA-TEST-2024-01",
-        "status": "Active",
+        "status": "Created",
         "shortTitle": "Test analysis",
     }
 )
@@ -40,7 +40,7 @@ SAMPLE_ANALYSIS = Analysis.model_validate(
 SAMPLE_PAPER = Paper.model_validate(
     {
         "referenceCode": "HDBS-2024-01",
-        "status": "Published",
+        "status": "Phase 1 Active",
         "shortTitle": "Test paper",
     }
 )
@@ -48,7 +48,7 @@ SAMPLE_PAPER = Paper.model_validate(
 SAMPLE_CONF_NOTE = ConfNote.model_validate(
     {
         "temporaryReferenceCode": "ATLAS-CONF-2024-001",
-        "status": "Active",
+        "status": "Completed",
         "shortTitle": "Test conf note",
     }
 )
@@ -56,7 +56,7 @@ SAMPLE_CONF_NOTE = ConfNote.model_validate(
 SAMPLE_PUB_NOTE = PubNote.model_validate(
     {
         "temporaryReferenceCode": "ATL-PHYS-PUB-2024-001",
-        "status": "Active",
+        "status": "Phase 1 Closed",
         "shortTitle": "Test pub note",
     }
 )
@@ -67,7 +67,7 @@ SAMPLE_SEARCH = AnalysisSearchResult.model_validate(
         "results": [
             {
                 "referenceCode": "ANA-TEST-2024-01",
-                "status": "Active",
+                "status": "Phase 0 Active",
                 "shortTitle": "Test analysis",
             }
         ],
@@ -80,7 +80,7 @@ SAMPLE_PAPER_SEARCH = PaperSearchResult.model_validate(
         "results": [
             {
                 "referenceCode": "HDBS-2024-01",
-                "status": "Published",
+                "status": "Phase 2 Active",
                 "shortTitle": "Test paper",
             }
         ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,12 @@ from typer.testing import CliRunner
 from stare import __version__
 from stare.cli import app
 from stare.dsl.errors import DSLValidationError
-from stare.exceptions import AuthenticationError, EnrichedErrorResponse, NotFoundError, ResponseParseError
+from stare.exceptions import (
+    AuthenticationError,
+    EnrichedErrorResponse,
+    NotFoundError,
+    ResponseParseError,
+)
 from stare.models import (
     Analysis,
     AnalysisSearchResult,
@@ -686,12 +691,11 @@ def _make_parse_error(
         message="list type expected",
         snippet=snippet,
     )
-    err = ResponseParseError(
+    return ResponseParseError(
         f"Failed to parse AnalysisSearchResult (1 validation error):\n  1. {loc_str}: list type expected",
         raw_data=raw_data,
         details=[detail],
     )
-    return err
 
 
 def test_analysis_search_prints_snippet_panel_on_parse_error() -> None:
@@ -711,6 +715,26 @@ def test_analysis_search_prints_snippet_panel_on_parse_error() -> None:
     assert "not-a-list" in result.output
     # raw-response panel not shown without verbose
     assert "Raw API Response" not in result.output
+
+
+def test_analysis_search_verbose_includes_raw_panel() -> None:
+    """With --verbose, a Raw API Response panel is emitted when raw_data is set."""
+    bad_snippet = {"results": "not-a-list"}
+    exc = _make_parse_error(snippet=bad_snippet, raw_data={"results": "not-a-list"})
+    mock_g = _mock_glance()
+    mock_g.analyses.search.side_effect = exc
+    with patch("stare.cli.utils.make_glance", return_value=mock_g):
+        result = runner.invoke(app, ["analysis", "search", "--verbose", "--no-json"])
+    assert result.exit_code == 1
+    assert "Raw API Response" in result.output
+
+
+def test_analysis_search_passes_verbose_to_client() -> None:
+    """--verbose is forwarded as verbose=True to the resource search call."""
+    mock_g = _mock_glance()
+    with patch("stare.cli.utils.make_glance", return_value=mock_g):
+        runner.invoke(app, ["analysis", "search", "--verbose"])
+    assert mock_g.analyses.search.call_args.kwargs.get("verbose") is True
 
 
 def test_analysis_search_skips_snippet_panel_when_snippet_is_none() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -486,6 +486,38 @@ def test_analyses_search_raises_response_parse_error(glance: Glance) -> None:
     assert any("results" in d.loc_str for d in exc_info.value.details)
 
 
+def test_analyses_search_verbose_attaches_raw_data(glance: Glance) -> None:
+    """verbose=True attaches the raw payload to ResponseParseError."""
+    bad_json = {"results": "not-a-list"}
+    with respx.mock(base_url=_BASE) as rx:
+        rx.get("/searchAnalysis").mock(return_value=httpx.Response(200, json=bad_json))
+        with pytest.raises(ResponseParseError) as exc_info:
+            glance.analyses.search(verbose=True)
+    assert exc_info.value.raw_data == bad_json
+
+
+def test_papers_search_verbose_attaches_raw_data(glance: Glance) -> None:
+    """verbose=True on paper search attaches the raw payload."""
+    bad_json = {"results": "not-a-list"}
+    with respx.mock(base_url=_BASE) as rx:
+        rx.get("/searchPaper").mock(return_value=httpx.Response(200, json=bad_json))
+        with pytest.raises(ResponseParseError) as exc_info:
+            glance.papers.search(verbose=True)
+    assert exc_info.value.raw_data == bad_json
+
+
+def test_conf_notes_get_verbose_attaches_raw_data(glance: Glance) -> None:
+    """verbose=True on conf_notes.get attaches the raw payload."""
+    bad_json = {"analysisTeam": "not-a-list"}
+    with respx.mock(base_url=_BASE) as rx:
+        rx.get("/confnotes/ATL-PHYS-PUB-2024-001").mock(
+            return_value=httpx.Response(200, json=bad_json)
+        )
+        with pytest.raises(ResponseParseError) as exc_info:
+            glance.conf_notes.get("ATL-PHYS-PUB-2024-001", verbose=True)
+    assert exc_info.value.raw_data == bad_json
+
+
 def test_response_parse_error_is_stare_error(glance: Glance) -> None:
     """ResponseParseError is a StareError so existing CLI handlers catch it."""
     with respx.mock(base_url=_BASE) as rx:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -479,8 +479,11 @@ def test_analyses_search_raises_response_parse_error(glance: Glance) -> None:
     assert "AnalysisSearchResult" in msg
     assert "results" in msg
     assert "validation error" in msg.lower()
-    # raw_data lets callers (e.g. CLI) display the offending JSON
-    assert exc_info.value.raw_data == bad_json
+    # default verbose=False -> raw_data is not attached
+    assert exc_info.value.raw_data is None
+    # details are always enriched with snippet + location info
+    assert exc_info.value.details
+    assert any("results" in d.loc_str for d in exc_info.value.details)
 
 
 def test_response_parse_error_is_stare_error(glance: Glance) -> None:
@@ -508,7 +511,7 @@ def test_format_parse_error_with_nested_loc() -> None:
     try:
         _Tmp.model_validate({"items": "not-a-list"})
     except ValidationError as exc:
-        msg = _format_parse_error("_Tmp", exc)
+        msg, _details = _format_parse_error("_Tmp", exc)
 
     assert "_Tmp" in msg
     assert "items" in msg
@@ -524,7 +527,7 @@ def test_format_parse_error_integer_index_uses_brackets() -> None:
     try:
         _M.model_validate({"items": ["ok", 123]})
     except ValidationError as exc:
-        msg = _format_parse_error("_M", exc)
+        msg, _details = _format_parse_error("_M", exc)
 
     assert "items[1]" in msg
 
@@ -547,7 +550,7 @@ def test_format_parse_error_with_obj_extracts_reference_code() -> None:
             {"referenceCode": "ANA-C"},
         ]
     }
-    msg = _format_parse_error("SearchResult", mock_error, obj=obj)
+    msg, _details = _format_parse_error("SearchResult", mock_error, obj=obj)
     assert "results[2]" in msg
     assert "ANA-C" in msg
 
@@ -559,6 +562,6 @@ def test_format_parse_error_empty_loc() -> None:
         {"loc": (), "msg": "something broke", "type": "value_error"}
     ]
 
-    msg = _format_parse_error("MyModel", mock_error)
+    msg, _details = _format_parse_error("MyModel", mock_error)
     assert "(root)" in msg
     assert "something broke" in msg

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,11 +46,11 @@ _BASE = "https://test-glance.example.com/api"
 
 SAMPLE_ANALYSIS = {
     "referenceCode": "ANA-TEST-2024-01",
-    "status": "Active",
+    "status": "Phase 0 Active",
     "shortTitle": "Test analysis",
     "publicShortTitle": "Public test",
     "groups": {"leadingGroup": "HDBS", "subgroups": [], "otherGroups": []},
-    "phase0": {"state": "Approved"},
+    "phase0": {"state": "Auxiliary metadata"},
 }
 
 SAMPLE_SEARCH = {
@@ -60,7 +60,7 @@ SAMPLE_SEARCH = {
 
 SAMPLE_PAPER = {
     "referenceCode": "HDBS-2024-01",
-    "status": "Published",
+    "status": "Completed",
     "shortTitle": "Test paper",
 }
 
@@ -71,13 +71,13 @@ SAMPLE_PAPER_SEARCH = {
 
 SAMPLE_CONF_NOTE = {
     "temporaryReferenceCode": "ATLAS-CONF-2024-001",
-    "status": "Active",
+    "status": "Phase 1 Closed",
     "shortTitle": "Test conf note",
 }
 
 SAMPLE_PUB_NOTE = {
     "temporaryReferenceCode": "ATL-PHYS-PUB-2024-001",
-    "status": "Active",
+    "status": "Phase 1 Active",
     "shortTitle": "Test pub note",
 }
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -82,7 +82,7 @@ class TestPaperStatus:
         M = _model(PaperStatus)
         assert (
             M.model_validate({"value": "Completed"}).value
-            == PaperStatus.SUBMISSION_CLOSED
+            == PaperStatus.SUBMISSION_COMPLETED
         )
 
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -304,14 +304,6 @@ class TestCollisionType:
 
 
 class TestRepositoryType:
-    def test_known_values(self) -> None:
-        M = _model(LenientRepositoryType)
-        assert M.model_validate({"value": "analysis"}).value == RepositoryType.ANALYSIS
-        assert M.model_validate({"value": "thesis"}).value == RepositoryType.THESIS
-        assert (
-            M.model_validate({"value": "framework"}).value == RepositoryType.FRAMEWORK
-        )
-
     def test_publication_shortcode_values(self) -> None:
         M = _model(LenientRepositoryType)
         assert M.model_validate({"value": "CONF"}).value == RepositoryType.CONF

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from pydantic import BaseModel
@@ -10,9 +9,6 @@ from pydantic import BaseModel
 from stare.models.enums import (
     AnalysisStatus,
     CollisionType,
-    LenientCollisionType,
-    LenientPublicationType,
-    LenientRepositoryType,
     PaperStatus,
     Phase0State,
     Phase1State,
@@ -275,7 +271,7 @@ class TestSubmissionState:
 
 class TestCollisionType:
     def test_known_values(self) -> None:
-        M = _model(LenientCollisionType)
+        M = _model(CollisionType)
         assert M.model_validate({"value": "p-p"}).value == CollisionType.PP
         assert M.model_validate({"value": "Pb-Pb"}).value == CollisionType.PB_PB
         assert M.model_validate({"value": "p-Pb"}).value == CollisionType.P_PB
@@ -290,13 +286,6 @@ class TestCollisionType:
             == CollisionType.TERT_COL_TYPE
         )
 
-    def test_unknown_falls_back(self, caplog) -> None:
-        M = _model(LenientCollisionType)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "n-n"})
-        assert result.value == "n-n"
-        assert "CollisionType" in caplog.text
-
 
 # ---------------------------------------------------------------------------
 # RepositoryType
@@ -305,26 +294,11 @@ class TestCollisionType:
 
 class TestRepositoryType:
     def test_known_values(self) -> None:
-        M = _model(LenientRepositoryType)
-        assert M.model_validate({"value": "analysis"}).value == RepositoryType.ANALYSIS
-        assert M.model_validate({"value": "thesis"}).value == RepositoryType.THESIS
-        assert (
-            M.model_validate({"value": "framework"}).value == RepositoryType.FRAMEWORK
-        )
-
-    def test_publication_shortcode_values(self) -> None:
-        M = _model(LenientRepositoryType)
+        M = _model(RepositoryType)
         assert M.model_validate({"value": "CONF"}).value == RepositoryType.CONF
         assert M.model_validate({"value": "INT"}).value == RepositoryType.INT
         assert M.model_validate({"value": "PAP"}).value == RepositoryType.PAP
         assert M.model_validate({"value": "PUB"}).value == RepositoryType.PUB
-
-    def test_unknown_falls_back(self, caplog) -> None:
-        M = _model(LenientRepositoryType)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "software"})
-        assert result.value == "software"
-        assert "RepositoryType" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -334,20 +308,13 @@ class TestRepositoryType:
 
 class TestPublicationType:
     def test_known_values(self) -> None:
-        M = _model(LenientPublicationType)
+        M = _model(PublicationType)
         assert M.model_validate({"value": "Paper"}).value == PublicationType.PAPER
         assert (
             M.model_validate({"value": "ConfNote"}).value == PublicationType.CONF_NOTE
         )
         assert M.model_validate({"value": "PubNote"}).value == PublicationType.PUB_NOTE
         assert M.model_validate({"value": "Analysis"}).value == PublicationType.ANALYSIS
-
-    def test_unknown_falls_back(self, caplog) -> None:
-        M = _model(LenientPublicationType)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "Dataset"})
-        assert result.value == "Dataset"
-        assert "PublicationType" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from pydantic import BaseModel
@@ -9,6 +10,9 @@ from pydantic import BaseModel
 from stare.models.enums import (
     AnalysisStatus,
     CollisionType,
+    LenientCollisionType,
+    LenientPublicationType,
+    LenientRepositoryType,
     PaperStatus,
     Phase0State,
     Phase1State,
@@ -271,7 +275,7 @@ class TestSubmissionState:
 
 class TestCollisionType:
     def test_known_values(self) -> None:
-        M = _model(CollisionType)
+        M = _model(LenientCollisionType)
         assert M.model_validate({"value": "p-p"}).value == CollisionType.PP
         assert M.model_validate({"value": "Pb-Pb"}).value == CollisionType.PB_PB
         assert M.model_validate({"value": "p-Pb"}).value == CollisionType.P_PB
@@ -286,6 +290,13 @@ class TestCollisionType:
             == CollisionType.TERT_COL_TYPE
         )
 
+    def test_unknown_falls_back(self, caplog) -> None:
+        M = _model(LenientCollisionType)
+        with caplog.at_level(logging.WARNING, logger="stare"):
+            result = M.model_validate({"value": "n-n"})
+        assert result.value == "n-n"
+        assert "CollisionType" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # RepositoryType
@@ -294,11 +305,26 @@ class TestCollisionType:
 
 class TestRepositoryType:
     def test_known_values(self) -> None:
-        M = _model(RepositoryType)
+        M = _model(LenientRepositoryType)
+        assert M.model_validate({"value": "analysis"}).value == RepositoryType.ANALYSIS
+        assert M.model_validate({"value": "thesis"}).value == RepositoryType.THESIS
+        assert (
+            M.model_validate({"value": "framework"}).value == RepositoryType.FRAMEWORK
+        )
+
+    def test_publication_shortcode_values(self) -> None:
+        M = _model(LenientRepositoryType)
         assert M.model_validate({"value": "CONF"}).value == RepositoryType.CONF
         assert M.model_validate({"value": "INT"}).value == RepositoryType.INT
         assert M.model_validate({"value": "PAP"}).value == RepositoryType.PAP
         assert M.model_validate({"value": "PUB"}).value == RepositoryType.PUB
+
+    def test_unknown_falls_back(self, caplog) -> None:
+        M = _model(LenientRepositoryType)
+        with caplog.at_level(logging.WARNING, logger="stare"):
+            result = M.model_validate({"value": "software"})
+        assert result.value == "software"
+        assert "RepositoryType" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -308,13 +334,20 @@ class TestRepositoryType:
 
 class TestPublicationType:
     def test_known_values(self) -> None:
-        M = _model(PublicationType)
+        M = _model(LenientPublicationType)
         assert M.model_validate({"value": "Paper"}).value == PublicationType.PAPER
         assert (
             M.model_validate({"value": "ConfNote"}).value == PublicationType.CONF_NOTE
         )
         assert M.model_validate({"value": "PubNote"}).value == PublicationType.PUB_NOTE
         assert M.model_validate({"value": "Analysis"}).value == PublicationType.ANALYSIS
+
+    def test_unknown_falls_back(self, caplog) -> None:
+        M = _model(LenientPublicationType)
+        with caplog.at_level(logging.WARNING, logger="stare"):
+            result = M.model_validate({"value": "Dataset"})
+        assert result.value == "Dataset"
+        assert "PublicationType" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -10,16 +10,16 @@ from pydantic import BaseModel
 from stare.models.enums import (
     AnalysisStatus,
     CollisionType,
-    LenientAnalysisStatus,
     LenientCollisionType,
-    LenientPaperStatus,
-    LenientPhaseState,
     LenientPublicationType,
     LenientRepositoryType,
     PaperStatus,
-    PhaseState,
+    Phase0State,
+    Phase1State,
+    Phase2State,
     PublicationType,
     RepositoryType,
+    SubmissionState,
 )
 
 # ---------------------------------------------------------------------------
@@ -43,8 +43,7 @@ def _model(lenient_type: Any) -> Any:
 
 class TestAnalysisStatus:
     def test_known_values_parse(self) -> None:
-        M = _model(LenientAnalysisStatus)
-        assert M.model_validate({"value": "Active"}).value == AnalysisStatus.ACTIVE
+        M = _model(AnalysisStatus)
         assert (
             M.model_validate({"value": "Analysis Closed"}).value
             == AnalysisStatus.ANALYSIS_CLOSED
@@ -59,25 +58,17 @@ class TestAnalysisStatus:
         )
         assert M.model_validate({"value": "Created"}).value == AnalysisStatus.CREATED
 
-    def test_unknown_value_falls_back_to_str(self, caplog) -> None:
-        M = _model(LenientAnalysisStatus)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "Future Status"})
-        assert result.value == "Future Status"
-        assert "AnalysisStatus" in caplog.text
-        assert "Future Status" in caplog.text
-
     def test_enum_compares_equal_to_string(self) -> None:
-        assert AnalysisStatus.ACTIVE.value == "Active"
+        assert AnalysisStatus.CREATED.value == "Created"
 
     def test_round_trip(self) -> None:
-        M = _model(LenientAnalysisStatus)
-        m = M.model_validate({"value": "Active"})
+        M = _model(AnalysisStatus)
+        m = M.model_validate({"value": "Created"})
         dumped = m.model_dump()
-        assert dumped["value"] == "Active"
+        assert dumped["value"] == "Created"
 
     def test_none_default(self) -> None:
-        M = _model(LenientAnalysisStatus)
+        M = _model(AnalysisStatus)
         assert M.model_validate({}).value is None
 
 
@@ -88,19 +79,11 @@ class TestAnalysisStatus:
 
 class TestPaperStatus:
     def test_known_values_parse(self) -> None:
-        M = _model(LenientPaperStatus)
-        assert M.model_validate({"value": "Active"}).value == PaperStatus.ACTIVE
+        M = _model(PaperStatus)
         assert (
-            M.model_validate({"value": "Submission Closed"}).value
+            M.model_validate({"value": "Completed"}).value
             == PaperStatus.SUBMISSION_CLOSED
         )
-
-    def test_unknown_value_falls_back(self, caplog) -> None:
-        M = _model(LenientPaperStatus)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "Unknown"})
-        assert result.value == "Unknown"
-        assert "PaperStatus" in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -108,69 +91,181 @@ class TestPaperStatus:
 # ---------------------------------------------------------------------------
 
 
-class TestPhaseState:
+class TestPhase0State:
     def test_human_readable_states(self) -> None:
-        M = _model(LenientPhaseState)
-        assert M.model_validate({"value": "Active"}).value == PhaseState.ACTIVE
-        assert M.model_validate({"value": "Approved"}).value == PhaseState.APPROVED
-        assert M.model_validate({"value": "finished"}).value == PhaseState.FINISHED
-
-    def test_internal_workflow_states(self) -> None:
-        M = _model(LenientPhaseState)
+        M = _model(Phase0State)
         assert (
-            M.model_validate({"value": "approval_acceptance"}).value
-            == PhaseState.APPROVAL_ACCEPTANCE
+            M.model_validate({"value": "Phase 0 Data"}).value == Phase0State.NOT_STARTED
         )
         assert (
-            M.model_validate({"value": "publication_draft"}).value
-            == PhaseState.PUBLICATION_DRAFT
+            M.model_validate({"value": "Publications definition"}).value
+            == Phase0State.FINISHED
+        )
+
+    def test_internal_workflow_states(self) -> None:
+        M = _model(Phase0State)
+        assert (
+            M.model_validate({"value": "Approval acceptance"}).value
+            == Phase0State.APPROVAL_ACCEPTANCE
+        )
+        assert (
+            M.model_validate({"value": "Publication draft"}).value
+            == Phase0State.PUBLICATION_DRAFT
         )
 
     def test_live_api_workflow_states(self) -> None:
-        M = _model(LenientPhaseState)
+        M = _model(Phase0State)
         assert (
-            M.model_validate({"value": "analysis_definition"}).value
-            == PhaseState.ANALYSIS_DEFINITION
-        )
-        assert M.model_validate({"value": "conf_skip"}).value == PhaseState.CONF_SKIP
-        assert (
-            M.model_validate({"value": "paper_contact_editors_definition"}).value
-            == PhaseState.PAPER_CONTACT_EDITORS_DEFINITION
+            M.model_validate({"value": "Analysis definition after EOI meeting"}).value
+            == Phase0State.ANALYSIS_DEFINITION
         )
         assert (
-            M.model_validate({"value": "phase0_active"}).value
-            == PhaseState.PHASE0_ACTIVE
+            M.model_validate({"value": "Skipped to CONF Note"}).value
+            == Phase0State.CONF_SKIP
         )
 
     def test_additional_workflow_states(self) -> None:
-        M = _model(LenientPhaseState)
+        M = _model(Phase0State)
         assert (
-            M.model_validate({"value": "analysis_coordinators_selection"}).value
-            == PhaseState.ANALYSIS_COORDINATORS_SELECTION
+            M.model_validate(
+                {"value": "Analysis contact and expert review selection"}
+            ).value
+            == Phase0State.ANALYSIS_COORDINATORS_SELECTION
         )
         assert (
-            M.model_validate({"value": "analysis_coordinators_timeline"}).value
-            == PhaseState.ANALYSIS_COORDINATORS_TIMELINE
+            M.model_validate({"value": "Analysis contacts' target date"}).value
+            == Phase0State.ANALYSIS_COORDINATORS_TIMELINE
         )
         assert (
-            M.model_validate({"value": "approval_meeting_data"}).value
-            == PhaseState.APPROVAL_MEETING
+            M.model_validate({"value": "Approval meeting data"}).value
+            == Phase0State.APPROVAL_MEETING_DATA
         )
         assert (
-            M.model_validate({"value": "eoi_meeting"}).value == PhaseState.EOI_MEETING
+            M.model_validate(
+                {"value": "Expression of interest (EOI) meeting data"}
+            ).value
+            == Phase0State.EOI_MEETING
         )
         assert (
-            M.model_validate({"value": "pub_contact_editors_definition"}).value
-            == PhaseState.PUB_CONTACT_EDITORS_DEFINITION
+            M.model_validate({"value": "Skipped to PUB Note"}).value
+            == Phase0State.PUB_SKIP
         )
-        assert M.model_validate({"value": "pub_skip"}).value == PhaseState.PUB_SKIP
 
-    def test_unknown_state_falls_back(self, caplog) -> None:
-        M = _model(LenientPhaseState)
-        with caplog.at_level(logging.WARNING, logger="stare"):
-            result = M.model_validate({"value": "some_future_state"})
-        assert result.value == "some_future_state"
-        assert "PhaseState" in caplog.text
+
+class TestPhase1State:
+    def test_human_readable_states(self) -> None:
+        M = _model(Phase1State)
+        assert (
+            M.model_validate({"value": "Phase 1 Data"}).value == Phase1State.NOT_STARTED
+        )
+        assert M.model_validate({"value": "Phase Closed"}).value == Phase1State.FINISHED
+
+    def test_internal_workflow_states(self) -> None:
+        M = _model(Phase1State)
+        assert (
+            M.model_validate({"value": "Analysis Review"}).value
+            == Phase1State.APPROVED_BY_REVIEWER
+        )
+        assert (
+            M.model_validate({"value": "Editorial Board Draft Sign-off"}).value
+            == Phase1State.LGP_APPROVED
+        )
+
+    def test_live_api_workflow_states(self) -> None:
+        M = _model(Phase1State)
+        assert (
+            M.model_validate({"value": "Editorial Board"}).value == Phase1State.STARTED
+        )
+        assert (
+            M.model_validate({"value": "Draft 1 Released to ATLAS"}).value
+            == Phase1State.REVIEW_CLOSED
+        )
+
+
+class TestPhase2State:
+    def test_human_readable_states(self) -> None:
+        M = _model(Phase2State)
+        assert M.model_validate({"value": "Phase 2 Data"}).value == Phase2State.STARTED
+        assert M.model_validate({"value": "Phase Closed"}).value == Phase2State.FINISHED
+
+    def test_internal_workflow_states(self) -> None:
+        M = _model(Phase2State)
+        assert (
+            M.model_validate({"value": "Draft 2 Approval Process"}).value
+            == Phase2State.FINAL_REVIEW_CLOSED
+        )
+        assert (
+            M.model_validate(
+                {"value": "Revised Draft Final Sign-off by Editorial Board Chair"}
+            ).value
+            == Phase2State.UPDATE_EDBOARD
+        )
+
+    def test_live_api_workflow_states(self) -> None:
+        M = _model(Phase2State)
+        assert (
+            M.model_validate(
+                {
+                    "value": "Revised Draft Final Sign-off by Publication Committee Chair or Deputy"
+                }
+            ).value
+            == Phase2State.UPDATED_PUBCOMM
+        )
+
+    def test_additional_workflow_states(self) -> None:
+        M = _model(Phase2State)
+        assert (
+            M.model_validate(
+                {"value": "Final Sign-off by Spokesperson or Deputy"}
+            ).value
+            == Phase2State.UPDATED_SPOKESPERSONDATE
+        )
+
+
+class TestSubmissionState:
+    def test_human_readable_states(self) -> None:
+        M = _model(SubmissionState)
+        assert (
+            M.model_validate({"value": "Publication Phase Launch"}).value
+            == SubmissionState.NOT_STARTED
+        )
+        assert (
+            M.model_validate({"value": "Submission Closed"}).value
+            == SubmissionState.FINISHED
+        )
+
+    def test_internal_workflow_states(self) -> None:
+        M = _model(SubmissionState)
+        assert (
+            M.model_validate({"value": "Journal Submission"}).value
+            == SubmissionState.SUBMITTED_TO_ARXIV
+        )
+        assert (
+            M.model_validate({"value": "Journal Reports Receiving"}).value
+            == SubmissionState.SUBMITTED_TO_JOURNAL
+        )
+
+    def test_live_api_workflow_states(self) -> None:
+        M = _model(SubmissionState)
+        assert (
+            M.model_validate({"value": "Journal Reports Answering"}).value
+            == SubmissionState.JOURNAL_REPORT_RECEIVED
+        )
+        assert (
+            M.model_validate({"value": "Final ArXiv Replacement"}).value
+            == SubmissionState.PUBLISHED_ONLINE
+        )
+
+    def test_additional_workflow_states(self) -> None:
+        M = _model(SubmissionState)
+        assert (
+            M.model_validate({"value": "Erratum Submission"}).value
+            == SubmissionState.ERRATUM_REQUESTED
+        )
+        assert (
+            M.model_validate({"value": "Paper Finish"}).value
+            == SubmissionState.FINAL_ARXIV_REPLACED
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +277,7 @@ class TestCollisionType:
     def test_known_values(self) -> None:
         M = _model(LenientCollisionType)
         assert M.model_validate({"value": "p-p"}).value == CollisionType.PP
-        assert M.model_validate({"value": "Pb-Pb"}).value == CollisionType.PBPB
+        assert M.model_validate({"value": "Pb-Pb"}).value == CollisionType.PB_PB
         assert M.model_validate({"value": "p-Pb"}).value == CollisionType.P_PB
         assert M.model_validate({"value": "Xe-Xe"}).value == CollisionType.XE_XE
         assert M.model_validate({"value": "Col type"}).value == CollisionType.COL_TYPE
@@ -262,5 +357,5 @@ class TestPublicationType:
 
 class TestNonStringPassthrough:
     def test_none_passes_through(self) -> None:
-        M = _model(LenientAnalysisStatus)
+        M = _model(AnalysisStatus)
         assert M.model_validate({"value": None}).value is None

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ import pytest
 from stare.exceptions import (
     ApiError,
     AuthenticationError,
+    EnrichedErrorResponse,
     ForbiddenError,
     NotFoundError,
     ResponseParseError,
@@ -89,8 +90,6 @@ class TestResponseParseError:
         assert err.details == []
 
     def test_details_stored_when_provided(self) -> None:
-        from stare.exceptions import EnrichedErrorResponse
-
         detail = EnrichedErrorResponse(
             loc=("results", 2),
             loc_str="results[2]",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -96,6 +96,7 @@ class TestResponseParseError:
             EnrichedErrorResponse(loc=("x",), loc_str="x", message="bad")
         )
         assert err2.details == []
+
     def test_details_stored_when_provided(self) -> None:
         detail = EnrichedErrorResponse(
             loc=("results", 2),

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -84,6 +84,21 @@ class TestResponseParseError:
         err = ResponseParseError("some error", raw_data=payload)
         assert err.raw_data == payload
 
+    def test_details_defaults_to_empty_list(self) -> None:
+        err = ResponseParseError("some error")
+        assert err.details == []
+
+    def test_details_stored_when_provided(self) -> None:
+        from stare.exceptions import EnrichedErrorResponse
+
+        detail = EnrichedErrorResponse(
+            loc=("results", 2),
+            loc_str="results[2]",
+            message="bad",
+        )
+        err = ResponseParseError("msg", details=[detail])
+        assert err.details == [detail]
+
 
 class TestAuthenticationErrors:
     def test_token_expired_error_message(self) -> None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -89,6 +89,13 @@ class TestResponseParseError:
         err = ResponseParseError("some error")
         assert err.details == []
 
+    def test_details_default_is_not_shared_between_instances(self) -> None:
+        err1 = ResponseParseError("err1")
+        err2 = ResponseParseError("err2")
+        err1.details.append(
+            EnrichedErrorResponse(loc=("x",), loc_str="x", message="bad")
+        )
+        assert err2.details == []
     def test_details_stored_when_provided(self) -> None:
         detail = EnrichedErrorResponse(
             loc=("results", 2),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -139,7 +139,7 @@ class TestCollision:
     def test_parse(self) -> None:
         c = Collision.model_validate(
             {
-                "type": "pp",
+                "type": "p-p",
                 "year": "2018",
                 "run": "2",
                 "ecmValue": "13",
@@ -148,7 +148,7 @@ class TestCollision:
                 "luminosityUnit": "fb-1",
             }
         )
-        assert c.type == "pp"
+        assert c.type == "p-p"
         assert c.ecm_value == "13"
         assert c.luminosity_unit == "fb-1"
 
@@ -163,7 +163,7 @@ class TestMetadata:
             {
                 "collisions": [
                     {
-                        "type": "pp",
+                        "type": "p-p",
                         "year": "2018",
                         "run": "2",
                         "ecmValue": "13",
@@ -176,7 +176,7 @@ class TestMetadata:
         )
         assert m.collisions is not None
         assert len(m.collisions) == 1
-        assert m.collisions[0].type == "pp"
+        assert m.collisions[0].type == "p-p"
 
     def test_optional_fields(self) -> None:
         m = Metadata.model_validate({})
@@ -195,7 +195,7 @@ class TestDocumentation:
                 "repositories": [
                     {
                         "gitlabId": "123",
-                        "type": "analysis",
+                        "type": "INT",
                         "url": "https://gitlab.cern.ch/r",
                     }
                 ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,6 +21,7 @@ from stare.models.common import (
     Person,
     RelatedPublication,
     TeamMember,
+    _extract_context,
 )
 from stare.models.enums import MeetingType
 from stare.models.errors import ApiErrorResponse
@@ -270,9 +271,9 @@ class TestRelatedPublication:
 class TestAnalysisPhase0:
     def test_parse_minimal(self) -> None:
         p = AnalysisPhase0.model_validate(
-            {"state": "Active", "startDate": "2022-01-01"}
+            {"state": "Phase 0 Data", "startDate": "2022-01-01"}
         )
-        assert p.state == "Active"
+        assert p.state == "Phase 0 Data"
         assert p.start_date == date(2022, 1, 1)
 
     def test_meetings_parsed(self) -> None:
@@ -339,13 +340,13 @@ class TestAnalysis:
         a = Analysis.model_validate(
             {
                 "referenceCode": "ANA-HION-2018-01",
-                "status": "Active",
+                "status": "Created",
                 "shortTitle": "My analysis",
                 "creationDate": "2022-01-01",
             }
         )
         assert a.reference_code == "ANA-HION-2018-01"
-        assert a.status == "Active"
+        assert a.status == "Created"
         assert a.short_title == "My analysis"
 
     def test_nested_groups(self) -> None:
@@ -366,11 +367,11 @@ class TestAnalysis:
         a = Analysis.model_validate(
             {
                 "referenceCode": "ANA-X",
-                "phase0": {"state": "Approved", "startDate": "2021-01-01"},
+                "phase0": {"state": "Approval acceptance", "startDate": "2021-01-01"},
             }
         )
         assert a.phase0 is not None
-        assert a.phase0.state == "Approved"
+        assert a.phase0.state == "Approval acceptance"
 
     def test_analysis_team(self) -> None:
         a = Analysis.model_validate(
@@ -525,8 +526,8 @@ class TestAnalysisSearchResult:
             {
                 "numberOfResults": 2,
                 "results": [
-                    {"referenceCode": "ANA-A", "status": "Active"},
-                    {"referenceCode": "ANA-B", "status": "Closed"},
+                    {"referenceCode": "ANA-A", "status": "Created"},
+                    {"referenceCode": "ANA-B", "status": "Analysis Closed"},
                 ],
             }
         )
@@ -598,3 +599,96 @@ class TestApiErrorResponse:
         e = ApiErrorResponse.model_validate({})
         assert e.status is None
         assert e.title is None
+
+
+def test_extracting_context():
+    loc_tuple = ("results", 0, "phase0", "state")
+    obj = {
+        "results": [
+            {
+                "creationDate": "2023-08-10T00:00:00+02:00",
+                "referenceCode": "ANA-SUSY-2023-17",
+                "status": "Analysis Closed",
+                "shortTitle": "NUHM2 reinterpretation",
+                "publicShortTitle": "NUHM2 reinterpretation",
+                "extraMetadata": {},
+                "groups": {
+                    "leadingGroup": "SUSY",
+                    "subgroups": ["SUSY-EW", "SUSY-Run2"],
+                    "otherGroups": [],
+                },
+                "analysisTeam": [
+                    {
+                        "cernCcid": "449340",
+                        "firstName": "Patrick",
+                        "lastName": "Skubic",
+                        "isContactEditor": True,
+                    },
+                    {
+                        "cernCcid": "664227",
+                        "firstName": "Judita",
+                        "lastName": "Mamuzic",
+                        "isContactEditor": True,
+                    },
+                ],
+                "metadata": {
+                    "collisions": [
+                        {
+                            "type": "p-p",
+                            "year": "2015+2016+2017+2018",
+                            "run": "Run 2",
+                            "ecmValue": "13",
+                            "ecmUnit": "TeV",
+                            "luminosityValue": "140",
+                            "luminosityUnit": "femtobarn-1",
+                        }
+                    ],
+                    "keywords": [
+                        "13 TeV",
+                        "2 leptons",
+                        ">=3 leptons",
+                        "BSM reinterpretation",
+                        "Higgsino production",
+                        "MET",
+                        "NUHM",
+                        "R21",
+                    ],
+                    "mvaMlTools": [],
+                    "triggers": [
+                        "HLT_xe100_mht_L1XE50",
+                        "HLT_xe70_mht",
+                        "HLT_xe90_mht_L1XE50",
+                        "HLT_xe110_pufit_L1XE50",
+                        "HLT_xe110_pufit_L1XE55",
+                        "HLT_xe110_pufit_xe65_L1XE50",
+                        "HLT_xe110_pufit_xe70_L1XE50",
+                        "HLT_xe110_mht_L1XE50",
+                    ],
+                },
+                "amiGlance": [],
+                "documentation": {
+                    "repositories": [
+                        {
+                            "gitlabId": "167424",
+                            "type": "INT",
+                            "url": "https://gitlab.cern.ch/atlas-physics-office/SUSY/ANA-SUSY-2023-17/ANA-SUSY-2023-17-INT1",
+                        }
+                    ],
+                    "supportingInternalDocuments": [],
+                },
+                "relatedPublications": [],
+                "phase0": {
+                    "state": "pub_contact_editors_definition",
+                    "startDate": "2023-08-10T00:00:00+02:00",
+                    "mainPhysicsAim": None,
+                    "datasetUsed": None,
+                    "modelTested": None,
+                    "methods": None,
+                    "editorialBoardFormedOn": None,
+                    "pgcOrSgcSignOffDate": None,
+                    "analysisContacts": [],
+                },
+            }
+        ]
+    }
+    assert _extract_context(obj, loc_tuple) == "referenceCode='ANA-SUSY-2023-17'"


### PR DESCRIPTION
- **update tests**
- **update the enums and strict-it-up**
- **fix(models): restore parse-error enrichment and repair stale tests**
- **feat(client): thread verbose kwarg to model_validate**
- **feat(cli): render per-error JSON snippet panels on parse error**
- **feat(cli): add --verbose flag to commands that parse API responses**
- **lint**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --verbose / -v CLI flag to relevant search/get commands to surface richer error context.

* **Improvements**
  * Enhanced error rendering to show structured validation details and per-detail snippets; when verbose, include the full raw API response.
  * Tightened workflow/status/phase enums and updated displayed labels across the CLI.

* **Tests**
  * Updated and added tests for verbose error rendering and revised enum/state behavior.

* **Documentation**
  * API enum docs updated to reflect new phase-specific enums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->