### PR TITLE
fix: various changes based on current api released today

### DIFF
--- a/src/stare/cli/confnote.py
+++ b/src/stare/cli/confnote.py
@@ -129,7 +129,9 @@ def confnote_search(
     table.add_column("Short Title")
     for item in result.results:
         ref = item.temp_reference_code
-        ref_cell = f"[link={confnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
+        ref_cell = (
+            f"[link={confnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
+        )
         table.add_row(ref_cell, item.status or "", item.short_title or "")
     utils.console.print(table)
 

--- a/src/stare/cli/confnote.py
+++ b/src/stare/cli/confnote.py
@@ -128,12 +128,8 @@ def confnote_search(
     table.add_column("Status")
     table.add_column("Short Title")
     for item in result.results:
-        ref = item.temp_reference_code or ""
-        ref_cell = (
-            f"[link={confnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
-            if ref
-            else ""
-        )
+        ref = item.temp_reference_code
+        ref_cell = f"[link={confnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
         table.add_row(ref_cell, item.status or "", item.short_title or "")
     utils.console.print(table)
 

--- a/src/stare/cli/pubnote.py
+++ b/src/stare/cli/pubnote.py
@@ -128,12 +128,8 @@ def pubnote_search(
     table.add_column("Status")
     table.add_column("Short Title")
     for item in result.results:
-        ref = item.final_reference_code or ""
-        ref_cell = (
-            f"[link={pubnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
-            if ref
-            else ""
-        )
+        ref = item.temp_reference_code
+        ref_cell = f"[link={pubnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
         table.add_row(ref_cell, item.status or "", item.short_title or "")
     utils.console.print(table)
 

--- a/src/stare/cli/pubnote.py
+++ b/src/stare/cli/pubnote.py
@@ -129,7 +129,9 @@ def pubnote_search(
     table.add_column("Short Title")
     for item in result.results:
         ref = item.temp_reference_code
-        ref_cell = f"[link={pubnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
+        ref_cell = (
+            f"[link={pubnote_url(ref, web_base=settings.web_base_url)}]{ref}[/link]"
+        )
         table.add_row(ref_cell, item.status or "", item.short_title or "")
     utils.console.print(table)
 

--- a/src/stare/models/analysis.py
+++ b/src/stare/models/analysis.py
@@ -47,6 +47,8 @@ _MEETING_API_KEY_TO_TYPE: dict[str, str] = {v: k for k, v in _MEETING_API_KEYS.i
 
 
 class AnalysisMetadata(Metadata):
+    """Additional physics and technical metadata for analyses."""
+
     triggers: list[Trigger] = Field(default_factory=list)
     analysis_framework: AnalysisFramework | None = None
 

--- a/src/stare/models/analysis.py
+++ b/src/stare/models/analysis.py
@@ -15,12 +15,14 @@ from rich.text import Text
 
 from stare.models.common import (
     AmiGlanceLink,
+    AnalysisFramework,
     AnalysisTeam,
     Documentation,
     EditorialBoard,
     Groups,
     Metadata,
     RelatedPublication,
+    Trigger,
     TypedMeeting,
     _Base,
 )
@@ -42,6 +44,11 @@ _MEETING_API_KEYS: dict[str, str] = {
     MeetingType.APPROVAL: "approvalMeeting",
 }
 _MEETING_API_KEY_TO_TYPE: dict[str, str] = {v: k for k, v in _MEETING_API_KEYS.items()}
+
+
+class AnalysisMetadata(Metadata):
+    triggers: list[Trigger] = Field(default_factory=list)
+    analysis_framework: AnalysisFramework | None = None
 
 
 class AnalysisPhase0(_Base):
@@ -115,7 +122,7 @@ class Analysis(_Base):
     ami_glance: list[AmiGlanceLink] = Field(default_factory=list)
     documentation: Documentation | None = None
     analysis_team: AnalysisTeam = Field(default_factory=AnalysisTeam)
-    metadata: Metadata | None = None
+    metadata: AnalysisMetadata | None = None
     related_publications: list[RelatedPublication] = Field(default_factory=list)
     phase0: AnalysisPhase0 | None = None
     extra_metadata: dict[str, Any] | None = None

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -276,8 +276,8 @@ class Trigger(_NamedItem):
 class AnalysisFramework(_Base):
     """Ntupling and histogramming framework names for an analysis."""
 
-    ntupling: str | None = None
-    histogramming: str | None = None
+    ntupling: list[str] = Field(default_factory=list)
+    histogramming: list[str] = Field(default_factory=list)
 
 
 class AnalysisContactAssignment(_Base):

--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -447,10 +447,6 @@ class Metadata(_Base):
     keywords: list[Keyword] = Field(default_factory=list)
     statistical_tools: list[StatTool] = Field(default_factory=list, alias="statTools")
     mva_ml_tools: list[MvaMlTool] = Field(default_factory=list, alias="mvaMlTools")
-    # Analysis endpoint only; empty for paper/confnote/pubnote.
-    triggers: list[Trigger] = Field(default_factory=list)
-    # Analysis endpoint only.
-    analysis_framework: AnalysisFramework | None = None
 
 
 class Repository(Link):

--- a/src/stare/models/enums.py
+++ b/src/stare/models/enums.py
@@ -233,8 +233,8 @@ class PublicationType(StrEnum):
     """Observed publication type values (cross-references between record types)."""
 
     PAPER = "Paper"
-    CONF_NOTE = "ConfNote"
-    PUB_NOTE = "PubNote"
+    CONF_NOTE = "CONF note"
+    PUB_NOTE = "PUB note"
     ANALYSIS = "Analysis"
 
 

--- a/src/stare/models/paper.py
+++ b/src/stare/models/paper.py
@@ -85,9 +85,9 @@ class PublicationPhase(_Base):
     physics_briefing: list[Link] = Field(default_factory=list)
     first_referee_report_date: date | None = None
     journal_acceptance_date: date | None = None
-    first_proof_date: date | None = Field(default=None, alias="1stProofDate")
+    first_proof_date: AwareDatetime | None = Field(default=None, alias="1stProofDate")
     final_journal_publication: list[Link] = Field(default_factory=list)
-    published_online_date: date | None = None
+    published_online_date: AwareDatetime | None = None
 
     @field_validator("arxiv_submission_date", mode="before")
     @classmethod

--- a/src/stare/models/pubnote.py
+++ b/src/stare/models/pubnote.py
@@ -77,8 +77,8 @@ class PubNotePhase1(_Base):
 class PubNote(_Base):
     """An ATLAS PUB note."""
 
-    temp_reference_code: str | None = Field(
-        default=None, alias="temporaryReferenceCode"
+    temp_reference_code: str = Field(
+        alias="temporaryReferenceCode", pattern=r"^PUB-[A-Z]{4}-\d{4}-\d{2}$"
     )
     final_reference_code: str | None = None
     status: PubnoteStatus | None = None
@@ -180,12 +180,13 @@ class PubNote(_Base):
 
         # --- Header ---
         settings = StareSettings()
-        ref = self.temp_reference_code or self.final_reference_code or ""
-        url = pubnote_url(ref, web_base=settings.web_base_url)
+        url = pubnote_url(self.temp_reference_code, web_base=settings.web_base_url)
 
-        header = Text.from_markup(f"[bold cyan][link={url}]{ref}[/link][/bold cyan]")
+        header = Text.from_markup(
+            f"[bold cyan][link={url}]{self.temp_reference_code}[/link][/bold cyan]"
+        )
 
-        if self.final_reference_code and self.final_reference_code != ref:
+        if self.final_reference_code:
             header.append(f" ({self.final_reference_code})", style="bold")
 
         if self.status:

--- a/tests/fixtures/pub_note.json
+++ b/tests/fixtures/pub_note.json
@@ -1,5 +1,5 @@
 {
-  "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+  "temporaryReferenceCode": "PUB-EXOT-2026-03",
   "finalReferenceCode": "ATL-PHYS-PUB-2024-01",
   "status": "Phase 1 Active",
   "shortTitle": "Test pub note"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ SAMPLE_CONF_NOTE = ConfNote.model_validate(
 
 SAMPLE_PUB_NOTE = PubNote.model_validate(
     {
-        "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+        "temporaryReferenceCode": "PUB-EXOT-2026-03",
         "finalReferenceCode": "ATL-PHYS-PUB-2024-01",
         "status": "Phase 1 Finished",
         "shortTitle": "Test pub note",
@@ -114,7 +114,7 @@ SAMPLE_PUB_NOTE_SEARCH = PubNoteSearchResult.model_validate(
         "numberOfResults": 1,
         "results": [
             {
-                "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+                "temporaryReferenceCode": "PUB-EXOT-2026-03",
                 "finalReferenceCode": "ATL-PHYS-PUB-2024-01",
                 "status": "Phase 1 Finished",
                 "shortTitle": "Test pub note",

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -427,9 +427,9 @@ class TestPublicationType:
         M = _model(LenientPublicationType)
         assert M.model_validate({"value": "Paper"}).value == PublicationType.PAPER
         assert (
-            M.model_validate({"value": "ConfNote"}).value == PublicationType.CONF_NOTE
+            M.model_validate({"value": "CONF note"}).value == PublicationType.CONF_NOTE
         )
-        assert M.model_validate({"value": "PubNote"}).value == PublicationType.PUB_NOTE
+        assert M.model_validate({"value": "PUB note"}).value == PublicationType.PUB_NOTE
         assert M.model_validate({"value": "Analysis"}).value == PublicationType.ANALYSIS
 
     def test_unknown_falls_back(self, caplog) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -189,8 +189,6 @@ class TestMetadata:
         assert m.keywords == []
         assert m.statistical_tools == []
         assert m.mva_ml_tools == []
-        assert m.triggers == []
-        assert m.analysis_framework is None
 
 
 class TestDocumentation:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1083,7 +1083,7 @@ class TestConfNote:
                 }
             )
 
-    def test_all_optional(self) -> None:
+    def test_final_reference_code_optional(self) -> None:
         note = ConfNote.model_validate(
             {
                 "temporaryReferenceCode": "CONF-EXOT-2024-01",
@@ -1165,7 +1165,7 @@ class TestPubNote:
                 }
             )
 
-    def test_all_optional(self) -> None:
+    def test_final_reference_code_optional(self) -> None:
         note = PubNote.model_validate(
             {
                 "temporaryReferenceCode": "PUB-EXOT-2026-03",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1175,6 +1175,10 @@ class TestPubNote:
         assert note.temp_reference_code == "PUB-EXOT-2026-03"
         assert note.final_reference_code is None
 
+    def test_missing_temp_reference_code_raises(self) -> None:
+        with pytest.raises(ResponseParseError):
+            PubNote.model_validate({"finalReferenceCode": "ATL-PHYS-PUB-2024-01"})
+
 
 class TestPubNotePhase1:
     def test_phase1_state_uses_confnote_enum(self) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -727,7 +727,7 @@ def test_pub_note_search_result_round_trip() -> None:
         "numberOfResults": 1,
         "results": [
             {
-                "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+                "temporaryReferenceCode": "PUB-EXOT-2026-03",
                 "finalReferenceCode": "ATL-PHYS-PUB-2024-01",
                 "status": "Phase 1 Active",
                 "shortTitle": "x",
@@ -959,7 +959,7 @@ class TestRichRendering:
     def test_pubnote_rich(self) -> None:
         pn = PubNote.model_validate(
             {
-                "temporaryReferenceCode": "ATL-PHYS-PUB-2024-99",
+                "temporaryReferenceCode": "PUB-EXOT-2026-03",
                 "status": "Phase 1 Active",
                 "shortTitle": "PubNote test",
                 "phase1": {
@@ -1043,7 +1043,7 @@ class TestRichRendering:
         )
         pn = PubNote.model_validate(
             {
-                "temporaryReferenceCode": "ATL-PHYS-PUB-2024-99",
+                "temporaryReferenceCode": "PUB-EXOT-2026-03",
                 "status": "Phase 1 Active",
             }
         )
@@ -1143,24 +1143,24 @@ class TestConfNoteSearchResult:
 class TestPubNote:
     def test_round_trip(self) -> None:
         payload = {
-            "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+            "temporaryReferenceCode": "PUB-EXOT-2026-03",
             "finalReferenceCode": "ATL-PHYS-PUB-2024-01",
             "status": "Phase 1 Active",
             "shortTitle": "Test pub note",
         }
         note = PubNote.model_validate(payload)
-        assert note.temp_reference_code == "ATL-COM-PHYS-2024-001"
+        assert note.temp_reference_code == "PUB-EXOT-2026-03"
         assert note.final_reference_code == "ATL-PHYS-PUB-2024-01"
         assert note.short_title == "Test pub note"
         dumped = note.model_dump(by_alias=True, exclude_none=True)
-        assert dumped["temporaryReferenceCode"] == "ATL-COM-PHYS-2024-001"
+        assert dumped["temporaryReferenceCode"] == "PUB-EXOT-2026-03"
         assert dumped["finalReferenceCode"] == "ATL-PHYS-PUB-2024-01"
 
     def test_strict_status_rejects_unknown(self) -> None:
         with pytest.raises(ResponseParseError):
             PubNote.model_validate(
                 {
-                    "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+                    "temporaryReferenceCode": "PUB-EXOT-2026-03",
                     "status": "SomeUnknownStatus",
                 }
             )
@@ -1168,11 +1168,11 @@ class TestPubNote:
     def test_all_optional(self) -> None:
         note = PubNote.model_validate(
             {
-                "temporaryReferenceCode": "ATL-COM-PHYS-2024-001",
+                "temporaryReferenceCode": "PUB-EXOT-2026-03",
                 "status": "Phase 1 Active",
             }
         )
-        assert note.temp_reference_code == "ATL-COM-PHYS-2024-001"
+        assert note.temp_reference_code == "PUB-EXOT-2026-03"
         assert note.final_reference_code is None
 
 


### PR DESCRIPTION
- **fix up paper dates -> datetime**
- **split analysismetadata off**
- **fix ntupling and enums for publication type**
- **fix up tests**
- **use self.temp_reference_code as guaranteed for pub and conf**
- **fix up tests, pre-commit**
- **add docstring**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference code display in search results for conference and publication notes.

* **New Features**
  * Enhanced Analysis model to support triggers and analysis framework metadata.
  * Added validation for temporary reference codes with standardized format requirements.

* **Changes**
  * Updated publication type string formats for improved consistency.
  * Expanded AnalysisFramework to support multiple ntupling and histogramming options.
  * Enhanced first proof date field to support datetime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->