### PR TITLE
feat(dsl): document and test __EMPTY__ NULL sentinel

### DIFF
--- a/docs/query-dsl.md
+++ b/docs/query-dsl.md
@@ -35,6 +35,23 @@ for which commands currently accept `--query`.
     Using `contain` or `not-contain` on these fields raises a `DSLValidationError` at parse time.
     Their values are typically `"true"` or `"false"`.
 
+!!! note "Comparing against NULL"
+
+    Use the special token `__EMPTY__` as the value to test whether a field is
+    `NULL`.  Both the bare and quoted forms are accepted; the API documentation
+    consistently uses the quoted form:
+
+    ```bash
+    # Find analyses with no public short title set
+    stare analysis search -q 'publicShortTitle = "__EMPTY__"'
+
+    # Find papers where shortTitle is not NULL
+    stare paper search -q 'shortTitle != "__EMPTY__"'
+    ```
+
+    `__EMPTY__` is treated as an ordinary string token by the parser — it
+    receives no special validation.
+
 ## Field names
 
 Fields accept either `camelCase` or `snake_case` — both are normalized to

--- a/src/stare/data/query-grammar.lark
+++ b/src/stare/data/query-grammar.lark
@@ -1,5 +1,9 @@
 // Generic DSL grammar — no field names hard-coded.
 // Syntax only; field/operator semantics validated downstream.
+//
+// NULL sentinel: the API-defined token __EMPTY__ (quoted or bare) is used to
+// compare a field against NULL, e.g.  "publicShortTitle" = "__EMPTY__".
+// It is matched as an ordinary VALUE (bare) or STRING (quoted) — no special rule.
 
 ?expression: or_expr
 ?or_expr: and_expr

--- a/tests/test_dsl_grammar.py
+++ b/tests/test_dsl_grammar.py
@@ -35,6 +35,10 @@ def parser() -> Lark:
         '"phase2.state" = "Phase Closed"',
         '"shortTitle" contain "Higgs"',
         'status = "Phase Closed" AND referenceCode = HION',
+        # __EMPTY__ NULL sentinel — bare and quoted forms
+        "publicShortTitle = __EMPTY__",
+        'publicShortTitle = "__EMPTY__"',
+        'publicShortTitle != "__EMPTY__"',
     ],
 )
 def test_parses_valid(parser: Lark, src: str) -> None:

--- a/tests/test_dsl_models.py
+++ b/tests/test_dsl_models.py
@@ -158,6 +158,14 @@ def test_value_with_non_space_whitespace_raises(value: str) -> None:
         c.to_dsl()
 
 
+def test_empty_sentinel_emitted_bare() -> None:
+    """__EMPTY__ contains no special chars, so to_dsl() emits it unquoted."""
+    c = Condition.model_validate(
+        {"field": "publicShortTitle", "operator": Operator.EQ, "value": "__EMPTY__"}
+    )
+    assert c.to_dsl() == "publicShortTitle = __EMPTY__"
+
+
 def test_multiword_value_round_trips() -> None:
     """parse_dsl → to_dsl is idempotent for double-quoted multi-word values."""
     src = 'shortTitle = "Phase Closed"'

--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -188,6 +188,30 @@ def test_boolean_field_with_not_contain_raises() -> None:
         parse_dsl('"analysisTeam.isContactEditor" not-contain "true"', mode="analysis")
 
 
+# --- __EMPTY__ NULL sentinel ---
+
+
+def test_empty_sentinel_quoted() -> None:
+    expr = parse_dsl('publicShortTitle = "__EMPTY__"', mode="analysis")
+    assert isinstance(expr, Condition)
+    assert expr.field == "publicShortTitle"
+    assert expr.operator == "="
+    assert expr.value == "__EMPTY__"
+
+
+def test_empty_sentinel_bare() -> None:
+    expr = parse_dsl("publicShortTitle = __EMPTY__", mode="analysis")
+    assert isinstance(expr, Condition)
+    assert expr.value == "__EMPTY__"
+
+
+def test_empty_sentinel_ne_operator() -> None:
+    expr = parse_dsl('shortTitle != "__EMPTY__"', mode="analysis")
+    assert isinstance(expr, Condition)
+    assert expr.operator == "!="
+    assert expr.value == "__EMPTY__"
+
+
 def test_paper_boolean_field_operator_restriction() -> None:
     with pytest.raises(DSLValidationError):
         parse_dsl(


### PR DESCRIPTION
Resolves #28.

## Summary

- Adds a grammar comment in `query-grammar.lark` noting that `__EMPTY__` is the API-defined NULL sentinel (matched as a plain `VALUE` or `STRING` — no rule change needed)
- Adds a **"Comparing against NULL"** admonition to `docs/query-dsl.md` with examples, placed alongside the boolean-fields note
- Adds regression tests at three layers (grammar, parser, models) covering the bare form, quoted form, and `!=` operator

## Test Plan

- [x] `pixi run pre-commit` — all hooks pass
- [x] `pixi run test` — 582 passed
- [ ] Optional live check: `pixi run stare analysis search -q 'publicShortTitle = "__EMPTY__"'`