### PR TITLE
fix(models): harden common models against malformed API responses

### DIFF
--- a/src/stare/models/common.py
+++ b/src/stare/models/common.py
@@ -249,6 +249,20 @@ class RequiredLink(Link):
     url: str
 
 
+class BrokenLink(Link):
+    """A link whose url is null in the API response."""
+
+    label: str
+    url: None = None
+
+
+class BadLink(Link):
+    """A link whose url field holds the label value instead."""
+
+    label: None
+    url: str
+
+
 # Aliases for semantically-required-url contexts.
 AmiGlanceLink = RequiredLink
 InternalDocument = RequiredLink
@@ -262,6 +276,12 @@ class _NamedItem(_Base):
 
 class Group(_NamedItem):
     """A physics group (leading group, subgroup, or other group)."""
+
+
+class NullGroup(_Base):
+    """A leading group slot whose name field is null in the API response."""
+
+    name: None = None
 
 
 class Keyword(_NamedItem):
@@ -374,7 +394,7 @@ class AnalysisTeam(_TeamRichMixin, _ListRootModel[AnalysisTeamMember]):
 class Groups(_Base):
     """Leading group, subgroups, and other groups for a publication."""
 
-    leading_group: Group | None = None
+    leading_group: Group | NullGroup | None = None
     subgroups: list[Group] = Field(default_factory=list)
     other_groups: list[Group] = Field(default_factory=list)
 
@@ -485,7 +505,9 @@ class Documentation(_Base):
     """Repositories and supporting documents for a publication."""
 
     repositories: list[Repository] = Field(default_factory=list)
-    supporting_internal_documents: list[InternalDocument] = Field(default_factory=list)
+    supporting_internal_documents: list[InternalDocument | BrokenLink | BadLink] = (
+        Field(default_factory=list)
+    )
 
 
 class Meeting(_Base):
@@ -525,4 +547,4 @@ class RelatedPublication(_Base):
     """A reference to a related publication (analysis, paper, CONF/PUB note)."""
 
     reference_code: str | None = None
-    type: LenientPublicationType
+    type: LenientPublicationType | None = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -376,9 +376,9 @@ class TestRelatedPublication:
         r = RelatedPublication.model_validate({"type": "Paper"})
         assert r.reference_code is None
 
-    def test_type_required(self) -> None:
-        with pytest.raises(ResponseParseError):
-            RelatedPublication.model_validate({"referenceCode": "HDBS-2018-33"})
+    def test_type_optional(self) -> None:
+        r = RelatedPublication.model_validate({"referenceCode": "HDBS-2018-33"})
+        assert r.type is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `BrokenLink` and `BadLink` subclasses of `Link` to handle link objects where `url` is null or where the url/label fields are swapped
- Adds `NullGroup(_Base)` for leading-group slots where `name` is null
- `Groups.leading_group` now accepts `Group | NullGroup | None`
- `Documentation.supporting_internal_documents` now accepts `InternalDocument | BrokenLink | BadLink`
- `RelatedPublication.type` is now optional (`None` default) to handle records where the type field is absent

These all reflect shapes seen in live API responses that caused parse failures under `extra="forbid"`.

## Test plan

- [x] Existing `test_type_required` updated to `test_type_optional` (behaviour changed by design)
- [x] 582 unit tests passing
- [x] `pixi run pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced API response validation to gracefully handle edge cases with invalid or null values in data fields.

* **Tests**
  * Updated test coverage to reflect optional behavior for certain data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->